### PR TITLE
Accept plain integers in advanced LED config list

### DIFF
--- a/custom_components/lampie/config_flow.py
+++ b/custom_components/lampie/config_flow.py
@@ -395,7 +395,7 @@ class LampieFlowCoordinator:
         with suppress(ValueError):
             color = user_input[CONF_COLOR] = int(color)
         try:
-            Color.color_number(color)
+            Color.parse_or_validate_in_range(color)
         except InvalidColor as e:
             errors[CONF_COLOR] = f"invalid_color_{e.reason}"
             description_placeholders["color"] = str(color)

--- a/custom_components/lampie/types.py
+++ b/custom_components/lampie/types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import suppress
 from dataclasses import dataclass, field
 import datetime as dt
 from enum import Enum, IntEnum, StrEnum, auto
@@ -67,8 +68,8 @@ class Color(IntEnum):
         return color
 
     @staticmethod
-    def color_number(value: str | int) -> Color | int:
-        """Get a number in the valid color range.
+    def parse_or_validate_in_range(value: str | int) -> Color | int:
+        """Get a color or number in the valid color range.
 
         Validate an input value and convert to a number that's in the valid
         color range.
@@ -80,6 +81,9 @@ class Color(IntEnum):
             InvalidColor: If the color is invalid because it is not a valid
                 name, is not in range, or is the wrong type.
         """
+        with suppress(ValueError, TypeError):
+            value = int(value)
+
         if isinstance(value, str):
             return Color.parse(value)
         if isinstance(value, int):
@@ -153,9 +157,7 @@ class LEDConfig:
             config = {CONF_COLOR: str(config)}
 
         color = config.get(CONF_COLOR, Color.BLUE.name)
-        color = (
-            Color.parse(color) if isinstance(color, str) else Color.color_number(color)
-        )
+        color = Color.parse_or_validate_in_range(color)
         brightness: float = config.get(CONF_BRIGTNESS, 100.0)
         effect: Effect = getattr(
             Effect, config.get(CONF_EFFECT, Effect.SOLID.name).upper()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -178,6 +178,40 @@ FLOW_SCENARIOS = {
             }
         },
     },
+    "valid_led_config_abbreviated": {
+        "user_input": {
+            CONF_NAME: "Medicine",
+            CONF_COLOR: "",
+            CONF_SWITCH_ENTITIES: ["light.dining_room"],
+            SECTION_ADVANCED_OPTIONS: {
+                CONF_LED_CONFIG: [
+                    "red",
+                    "orange",
+                    "white",
+                    250,
+                    20,
+                    255,
+                    0,
+                ]
+            },
+        },
+        "priority_inputs": [],
+        "expected_result": {
+            "data": {
+                CONF_NAME: "Medicine",
+                CONF_SWITCH_ENTITIES: ["light.dining_room"],
+                CONF_LED_CONFIG: [
+                    "red",
+                    "orange",
+                    "white",
+                    250,
+                    20,
+                    255,
+                    0,
+                ],
+            }
+        },
+    },
     "missing_color": {
         "user_input": {
             CONF_NAME: "Medicine",


### PR DESCRIPTION
As [discussed here](https://community.home-assistant.io/t/lampie-notifications-on-multiple-inovelli-switches/911246/6).