### PR TITLE
Search related entities by `translation_key`

### DIFF
--- a/custom_components/lampie/orchestrator.py
+++ b/custom_components/lampie/orchestrator.py
@@ -164,11 +164,18 @@ class LampieOrchestrator:
             local_protetction_id = None
             disable_clear_notification_id = None
 
+            _LOGGER.debug(
+                "searching %s related entries: %s",
+                switch_id,
+                [(entry.unique_id, entry.translation_key) for entry in entity_entries],
+            )
+
             for entity_entry in entity_entries:
-                if entity_entry.unique_id.endswith("-local_protection"):
+                if entity_entry.translation_key == "local_protection":
                     local_protetction_id = entity_entry.entity_id
-                if entity_entry.unique_id.endswith(
-                    "-disable_clear_notifications_double_tap"
+                if (
+                    entity_entry.translation_key
+                    == "disable_clear_notifications_double_tap"
                 ):
                     disable_clear_notification_id = entity_entry.entity_id
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -79,6 +79,7 @@ def add_mock_switch(
         ZHA_DOMAIN,
         f"{object_id}-local_protection",
         suggested_object_id=f"{object_id}_local_protection",
+        translation_key="local_protection",
         device_id=device_entry.id,
     )
     entity_registry.async_get_or_create(
@@ -86,6 +87,7 @@ def add_mock_switch(
         ZHA_DOMAIN,
         f"{object_id}-disable_clear_notifications_double_tap",
         suggested_object_id=f"{object_id}_disable_config_2x_tap_to_clear_notifications",
+        translation_key="disable_clear_notifications_double_tap",
         device_id=device_entry.id,
     )
     return switch


### PR DESCRIPTION
This will perhaps have more overlap with future integrations like:

- #2
- #5