### PR TITLE
Improve start action response trace handling

### DIFF
--- a/custom_components/lampie/orchestrator.py
+++ b/custom_components/lampie/orchestrator.py
@@ -561,7 +561,7 @@ class LampieOrchestrator:
                     slug,
                     led_config_override=led_config,
                 )
-                response["leds"] = led_config
+                response = dict(response, leds=led_config)
 
         return _StartScriptResult(
             led_config=response.get("leds"),


### PR DESCRIPTION
The response object should not be mutated or the representation in the trace tools appears as the mutated value. This resolves that issue.