### PR TITLE
Fix dismissal of notifications with customizations

### DIFF
--- a/custom_components/lampie/orchestrator.py
+++ b/custom_components/lampie/orchestrator.py
@@ -403,7 +403,7 @@ class LampieOrchestrator:
             switch_id,
             led_config_source=led_config_source,
             led_config=led_config,
-            exclude={LEDConfigSourceType.SERVICE} if is_reset else set(),
+            exclude={LEDConfigSourceType.OVERRIDE} if is_reset else set(),
             log_context="override-switch",
         )
 
@@ -462,8 +462,8 @@ class LampieOrchestrator:
 
             if (
                 from_state.led_config_source
-                and from_state.led_config_source.type == LEDConfigSourceType.SERVICE
-                and LEDConfigSourceType.SERVICE not in exclude
+                and from_state.led_config_source.type == LEDConfigSourceType.OVERRIDE
+                and LEDConfigSourceType.OVERRIDE not in exclude
             ):
                 led_config_source = from_state.led_config_source
                 led_config = from_state.led_config
@@ -869,7 +869,7 @@ class LampieOrchestrator:
         elif all_clear:
             await self._switch_apply_notification_or_override(
                 switch_id,
-                exclude={LEDConfigSourceType.SERVICE},
+                exclude={LEDConfigSourceType.OVERRIDE},
                 dismissal_command=command,
                 via_switch_firmware=via_switch_firmware,
                 log_context=f"dismissed via {switch_id}",
@@ -966,7 +966,7 @@ class LampieOrchestrator:
             dismiss=partial(
                 self._switch_apply_notification_or_override,
                 switch_id,
-                exclude={LEDConfigSourceType.SERVICE},
+                exclude={LEDConfigSourceType.OVERRIDE},
                 log_context=f"override expired for {switch_id}",
             ),
             handle_expired=partial(

--- a/custom_components/lampie/services.py
+++ b/custom_components/lampie/services.py
@@ -72,7 +72,7 @@ async def _activate(
     slugs: list[str] = call.data[ATTR_NOTIFICATION]
     led_config: tuple[LEDConfig, ...] | None = call.data.get(ATTR_LED_CONFIG)
     led_config_source = (
-        LEDConfigSource(f"{','.join(slugs)}[custom]", LEDConfigSourceType.SERVICE)
+        LEDConfigSource(f"{','.join(slugs)}[custom]", LEDConfigSourceType.NOTIFICATION)
         if led_config is not None
         else None
     )
@@ -105,7 +105,7 @@ async def _override(
     name: str = call.data.get(ATTR_NAME) or f"{DOMAIN}.{SERVICE_NAME_OVERRIDE}"
     switch_ids: list[str] = call.data[ATTR_ENTITY_ID]
     led_config: tuple[LEDConfig, ...] | None = call.data[ATTR_LED_CONFIG]
-    led_config_source = LEDConfigSource(name, LEDConfigSourceType.SERVICE)
+    led_config_source = LEDConfigSource(name, LEDConfigSourceType.OVERRIDE)
 
     if led_config is None:  # none indicates a reset
         led_config_source = LEDConfigSource(None)

--- a/tests/snapshots/test_scenarios.ambr
+++ b/tests/snapshots/test_scenarios.ambr
@@ -65,6 +65,10 @@
     ),
   ])
 # ---
+# name: test_dismissal_from_switch[aux_double_press_with_notification_activation_customizing_leds][service_calls]
+  list([
+  ])
+# ---
 # name: test_dismissal_from_switch[aux_double_press_with_service_override][service_calls]
   list([
   ])
@@ -181,6 +185,10 @@
         'switch_id': 'light.kitchen',
       }),
     ),
+  ])
+# ---
+# name: test_dismissal_from_switch[config_double_press_with_notification_activation_customizing_leds][service_calls]
+  list([
   ])
 # ---
 # name: test_dismissal_from_switch[config_double_press_with_service_override][service_calls]
@@ -994,7 +1002,7 @@
       }),
     ),
     'led_config_source': dict({
-      'type': <LEDConfigSourceType.SERVICE: 'service'>,
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'lampie.override',
     }),
     'local_protection_id': 'switch.kitchen_local_protection',
@@ -3912,7 +3920,7 @@
       }),
     ),
     'led_config_source': dict({
-      'type': <LEDConfigSourceType.SERVICE: 'service'>,
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'lampie.override',
     }),
     'local_protection_id': 'switch.kitchen_local_protection',
@@ -4067,7 +4075,7 @@
       }),
     ),
     'led_config_source': dict({
-      'type': <LEDConfigSourceType.SERVICE: 'service'>,
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'lampie.override',
     }),
     'local_protection_id': 'switch.kitchen_local_protection',
@@ -4408,7 +4416,7 @@
       }),
     ),
     'led_config_source': dict({
-      'type': <LEDConfigSourceType.SERVICE: 'service'>,
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'customized_name',
     }),
     'local_protection_id': 'switch.kitchen_local_protection',
@@ -4880,7 +4888,7 @@
       }),
     ),
     'led_config_source': dict({
-      'type': <LEDConfigSourceType.SERVICE: 'service'>,
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'lampie.override',
     }),
     'local_protection_id': 'switch.entryway_local_protection',
@@ -5941,7 +5949,7 @@
       }),
     ),
     'led_config_source': dict({
-      'type': <LEDConfigSourceType.SERVICE: 'service'>,
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'lampie.override',
     }),
     'local_protection_id': 'switch.kitchen_local_protection',

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -61,7 +61,7 @@
         }),
       ]),
       'source': dict({
-        'type': 'service',
+        'type': 'override',
         'value': 'lampie.override',
       }),
     }),
@@ -228,7 +228,7 @@
       }),
     ),
     'led_config_source': dict({
-      'type': <LEDConfigSourceType.SERVICE: 'service'>,
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'lampie.override',
     }),
     'local_protection_id': 'switch.kitchen_local_protection',

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1900,12 +1900,28 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                 },
             ),
             Scenario(
+                f"{prefix}_double_press_with_notification_activation_customizing_leds",
+                {
+                    **_DISMISSAL_FROM_SWITCH_BASE,
+                    "initial_leds_on": [True],
+                    "initial_led_config_source": LEDConfigSource(
+                        "doors_open,second_slug[custom]",
+                        LEDConfigSourceType.NOTIFICATION,
+                    ),
+                    "steps": [{"event": {"command": command}}],
+                    "expected_notification_state": "off",
+                    "expected_leds_on": [],
+                    "expected_zha_calls": 0,
+                },
+            ),
+            Scenario(
                 f"{prefix}_double_press_with_service_override",
                 {
                     **_DISMISSAL_FROM_SWITCH_BASE,
                     "initial_leds_on": [True],
                     "initial_led_config_source": LEDConfigSource(
-                        f"{DOMAIN}.{SERVICE_NAME_OVERRIDE}", LEDConfigSourceType.SERVICE
+                        f"{DOMAIN}.{SERVICE_NAME_OVERRIDE}",
+                        LEDConfigSourceType.OVERRIDE,
                     ),
                     "steps": [{"event": {"command": command}}],
                     "expected_notification_state": "on",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -242,7 +242,7 @@ RESTORE_STATE_SCENARIOS = (
             "switch_info": LampieSwitchInfo(
                 led_config=(LEDConfig(Color.BLUE, effect=Effect.SOLID),),
                 led_config_source=LEDConfigSource(
-                    "lampie.override", LEDConfigSourceType.SERVICE
+                    "lampie.override", LEDConfigSourceType.OVERRIDE
                 ),
                 local_protection_id="unstored:entity_id",
                 disable_clear_notification_id="unstored:entity_id",
@@ -258,7 +258,7 @@ RESTORE_STATE_SCENARIOS = (
                     }
                 ],
                 "source": {
-                    "type": "service",
+                    "type": "override",
                     "value": "lampie.override",
                 },
             },


### PR DESCRIPTION
These are created via `lampie.activate` with a custom set of LEDs and the format for the slug is a list followed by a bracketed tag.