### PR TITLE
Fix a rare issue when dismissing an override

### DIFF
--- a/tests/snapshots/test_scenarios.ambr
+++ b/tests/snapshots/test_scenarios.ambr
@@ -279,6 +279,32 @@
   list([
   ])
 # ---
+# name: test_dismissal_from_switch[aux_double_press_with_service_override][zha_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+  ])
+# ---
 # name: test_dismissal_from_switch[aux_double_with_local_protection_and_2x_tap_and_block_dismissal_script][service_calls]
   list([
     tuple(
@@ -605,6 +631,32 @@
 # ---
 # name: test_dismissal_from_switch[config_double_press_with_service_override][service_calls]
   list([
+  ])
+# ---
+# name: test_dismissal_from_switch[config_double_press_with_service_override][zha_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
   ])
 # ---
 # name: test_dismissal_from_switch[config_double_with_local_protection_and_2x_tap_and_block_dismissal_script][service_calls]

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1929,7 +1929,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     "expected_led_config_source": LEDConfigSource(
                         "doors_open", LEDConfigSourceType.NOTIFICATION
                     ),
-                    "expected_zha_calls": 0,
+                    "expected_zha_calls": 1,
                 },
             ),
             Scenario(


### PR DESCRIPTION
If a switch was currently being used to display an override and a notification with the exact same LED config, dismissing the override would fail to issue commands to update the LEDs again to reflect that the notification was still active.

This resolves that issue.

This change additionally adds some refactoring to make change processing more consistent and easier to understand within the code base. The underlying state of the switch is stored when the firmware updates the LEDs. This allows the switch transition logic to always use the internal state of the switch to determine if any updates actually need to be made.