### PR TITLE
Add device link for non-primary switches

### DIFF
--- a/custom_components/lampie/helpers.py
+++ b/custom_components/lampie/helpers.py
@@ -8,8 +8,6 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.device import async_device_info_to_link_from_entity
 from homeassistant.util import slugify
 
 from .const import CONF_PRIORITY, DOMAIN
@@ -24,22 +22,6 @@ def is_primary_for_switch(entry: LampieConfigEntry, switch_id: str) -> bool:
     if not priorities:
         return True
     return bool(priorities[0] == slugify(entry.title))
-
-
-def lookup_device_info(
-    hass: HomeAssistant, entry: LampieConfigEntry, switch_id: str
-) -> dr.DeviceInfo:
-    device_info = async_device_info_to_link_from_entity(hass, switch_id)
-
-    if not device_info:
-        _LOGGER.warning(
-            "skipping creation of sensors for %s on %s because an associated "
-            "device could not be found",
-            switch_id,
-            entry.title,
-        )
-
-    return device_info
 
 
 def get_other_entries(


### PR DESCRIPTION
The config entry can still have a link to the switch device for non-primary switches. This improves the config entry UI.