### PR TITLE
Add brightness control to notifications

### DIFF
--- a/custom_components/lampie/config_flow.py
+++ b/custom_components/lampie/config_flow.py
@@ -29,6 +29,9 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
@@ -37,6 +40,7 @@ from homeassistant.util import slugify
 import voluptuous as vol
 
 from .const import (
+    CONF_BRIGHTNESS,
     CONF_COLOR,
     CONF_DURATION,
     CONF_EFFECT,
@@ -248,6 +252,9 @@ class LampieFlowCoordinator:
                         )
                     ),
                     vol.Optional(
+                        CONF_BRIGHTNESS,
+                    ): NumberSelector(NumberSelectorConfig(min=0.0, max=100.0, unit_of_measurement="%")),
+                    vol.Optional(
                         CONF_DURATION,
                     ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
                     vol.Required(
@@ -362,6 +369,7 @@ class LampieFlowCoordinator:
             self.entry_data = {**user_input, **advanced_options}
 
             if self.entry_data.get(CONF_LED_CONFIG):
+                self.entry_data.pop(CONF_BRIGHTNESS, None)
                 self.entry_data.pop(CONF_COLOR, None)
                 self.entry_data.pop(CONF_EFFECT, None)
                 self.entry_data.pop(CONF_DURATION, None)
@@ -413,7 +421,7 @@ class LampieFlowCoordinator:
         advanced_options = user_input.get(SECTION_ADVANCED_OPTIONS, {})
         led_config = advanced_options.get(CONF_LED_CONFIG, [])
 
-        for key in [CONF_COLOR, CONF_EFFECT, CONF_DURATION]:
+        for key in [CONF_BRIGHTNESS, CONF_COLOR, CONF_EFFECT, CONF_DURATION]:
             if user_input.get(key):
                 errors[SECTION_ADVANCED_OPTIONS] = "invalid_led_config_override"
                 description_placeholders["key"] = key

--- a/custom_components/lampie/const.py
+++ b/custom_components/lampie/const.py
@@ -31,6 +31,8 @@ CONF_PRIORITY: Final = "priority"
 CONF_START_ACTION: Final = "start_action"
 CONF_SWITCH_ENTITIES: Final = "switches"
 
+DEFAULT_BRIGHTNESS: Final = 100.0
+
 INOVELLI_MODELS = {
     "VZM30-SN",  # switch
     "VZM31-SN",  # two in one switch/dimmer

--- a/custom_components/lampie/coordinator.py
+++ b/custom_components/lampie/coordinator.py
@@ -11,11 +11,13 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import slugify
 
 from .const import (
+    CONF_BRIGHTNESS,
     CONF_COLOR,
     CONF_DURATION,
     CONF_EFFECT,
     CONF_LED_CONFIG,
     CONF_SWITCH_ENTITIES,
+    DEFAULT_BRIGHTNESS,
     DOMAIN,
 )
 from .types import LampieConfigEntry, LEDConfig
@@ -49,6 +51,7 @@ class LampieUpdateCoordinator(DataUpdateCoordinator[None]):
                     CONF_LED_CONFIG,
                     [
                         {
+                            CONF_BRIGHTNESS: config_entry.data.get(CONF_BRIGHTNESS, DEFAULT_BRIGHTNESS),
                             CONF_COLOR: config_entry.data.get(CONF_COLOR),
                             CONF_EFFECT: config_entry.data.get(CONF_EFFECT),
                             CONF_DURATION: config_entry.data.get(CONF_DURATION),

--- a/custom_components/lampie/translations/en.json
+++ b/custom_components/lampie/translations/en.json
@@ -20,6 +20,7 @@
         "step": {
             "user": {
                 "data": {
+                    "brightness": "Brightness",
                     "color": "Color, i.e. cyan or a number",
                     "duration": "Duration in seconds, 'HH:MM' or 'HH:MM:SS'",
                     "effect": "Effect type",
@@ -112,6 +113,7 @@
         "step": {
             "init": {
                 "data": {
+                    "brightness": "Brightness",
                     "color": "Color, i.e. cyan or a number",
                     "duration": "Duration in seconds, 'HH:MM' or 'HH:MM:SS'",
                     "effect": "Effect type",

--- a/custom_components/lampie/types.py
+++ b/custom_components/lampie/types.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_COLOR,
     CONF_DURATION,
     CONF_EFFECT,
+    DEFAULT_BRIGHTNESS,
 )
 
 if TYPE_CHECKING:
@@ -128,7 +129,7 @@ class LEDConfig:
 
     color: Color | int
     effect: Effect
-    brightness: float = 100.0
+    brightness: float = DEFAULT_BRIGHTNESS
     duration: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -161,7 +162,7 @@ class LEDConfig:
 
         color = config.get(CONF_COLOR, Color.BLUE.name)
         color = Color.parse_or_validate_in_range(color)
-        brightness: float = config.get(CONF_BRIGHTNESS, 100.0)
+        brightness: float = config.get(CONF_BRIGHTNESS, DEFAULT_BRIGHTNESS)
         effect: Effect = getattr(
             Effect, config.get(CONF_EFFECT, Effect.SOLID.name).upper()
         )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -117,7 +117,6 @@ FLOW_SCENARIOS = {
                     },
                     {
                         CONF_COLOR: "orange",
-                        # CONF_BRIGHTNESS not set here intentionally, assumes default
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
@@ -163,7 +162,6 @@ FLOW_SCENARIOS = {
                     },
                     {
                         CONF_COLOR: "orange",
-                        CONF_BRIGHTNESS: 100.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
@@ -259,26 +257,6 @@ FLOW_SCENARIOS = {
             "description_placeholders": {
                 "config_title": "Medicine",
             },
-        },
-    },
-    "missing_brightness": {
-        "user_input": {
-            CONF_NAME: "Medicine",
-            CONF_COLOR: "red",
-            CONF_EFFECT: "slow_blink",
-            CONF_SWITCH_ENTITIES: ["light.dining_room"],
-            CONF_DURATION: "4:00",
-        },
-        "priority_inputs": [],
-        "expected_result": {
-            "data": {
-                CONF_NAME: "Medicine",
-                CONF_COLOR: "red",
-                CONF_BRIGHTNESS: 100.0,
-                CONF_EFFECT: "slow_blink",
-                CONF_SWITCH_ENTITIES: ["light.dining_room"],
-                CONF_DURATION: "4:00",
-            }
         },
     },
     "invalid_color_string": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,6 +16,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.lampie.config_flow import SECTION_ADVANCED_OPTIONS
 from custom_components.lampie.const import (
+    CONF_BRIGHTNESS,
     CONF_COLOR,
     CONF_DURATION,
     CONF_EFFECT,
@@ -35,6 +36,7 @@ FLOW_SCENARIOS = {
         "user_input": {
             CONF_NAME: "Medicine",
             CONF_COLOR: "cyan",
+            CONF_BRIGHTNESS: 0.0,
             CONF_EFFECT: "slow_blink",
             CONF_SWITCH_ENTITIES: ["light.dining_room"],
             CONF_DURATION: "4:00",
@@ -44,6 +46,7 @@ FLOW_SCENARIOS = {
             "data": {
                 CONF_NAME: "Medicine",
                 CONF_COLOR: "cyan",
+                CONF_BRIGHTNESS: 0.0,
                 CONF_EFFECT: "slow_blink",
                 CONF_SWITCH_ENTITIES: ["light.dining_room"],
                 CONF_DURATION: "4:00",
@@ -54,6 +57,7 @@ FLOW_SCENARIOS = {
         "user_input": {
             CONF_NAME: "Medicine",
             CONF_COLOR: "cyan",
+            CONF_BRIGHTNESS: 1.0,
             CONF_EFFECT: "slow_blink",
             CONF_SWITCH_ENTITIES: ["light.kitchen"],
         },
@@ -67,6 +71,7 @@ FLOW_SCENARIOS = {
             "data": {
                 CONF_NAME: "Medicine",
                 CONF_COLOR: "cyan",
+                CONF_BRIGHTNESS: 1.0,
                 CONF_EFFECT: "slow_blink",
                 CONF_SWITCH_ENTITIES: ["light.kitchen"],
                 CONF_PRIORITY: {
@@ -106,31 +111,37 @@ FLOW_SCENARIOS = {
                 CONF_LED_CONFIG: [
                     {
                         CONF_COLOR: "red",
+                        CONF_BRIGHTNESS: 50.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
                     {
                         CONF_COLOR: "orange",
+                        # CONF_BRIGHTNESS not set here intentionally, assumes default
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
                     {
                         CONF_COLOR: "white",
+                        CONF_BRIGHTNESS: 75.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
                     {
                         CONF_COLOR: "red",
+                        CONF_BRIGHTNESS: 25.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
                     {
                         CONF_COLOR: "orange",
+                        CONF_BRIGHTNESS: 10.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
                     {
                         CONF_COLOR: "white",
+                        CONF_BRIGHTNESS: 0.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
@@ -146,31 +157,37 @@ FLOW_SCENARIOS = {
                 CONF_LED_CONFIG: [
                     {
                         CONF_COLOR: "red",
+                        CONF_BRIGHTNESS: 50.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
                     {
                         CONF_COLOR: "orange",
+                        CONF_BRIGHTNESS: 100.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
                     {
                         CONF_COLOR: "white",
+                        CONF_BRIGHTNESS: 75.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
                     {
                         CONF_COLOR: "red",
+                        CONF_BRIGHTNESS: 25.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
                     {
                         CONF_COLOR: "orange",
+                        CONF_BRIGHTNESS: 10.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
                     {
                         CONF_COLOR: "white",
+                        CONF_BRIGHTNESS: 0.0,
                         CONF_EFFECT: "slow_blink",
                         CONF_DURATION: "4:00",
                     },
@@ -242,6 +259,26 @@ FLOW_SCENARIOS = {
             "description_placeholders": {
                 "config_title": "Medicine",
             },
+        },
+    },
+    "missing_brightness": {
+        "user_input": {
+            CONF_NAME: "Medicine",
+            CONF_COLOR: "red",
+            CONF_EFFECT: "slow_blink",
+            CONF_SWITCH_ENTITIES: ["light.dining_room"],
+            CONF_DURATION: "4:00",
+        },
+        "priority_inputs": [],
+        "expected_result": {
+            "data": {
+                CONF_NAME: "Medicine",
+                CONF_COLOR: "red",
+                CONF_BRIGHTNESS: 100.0,
+                CONF_EFFECT: "slow_blink",
+                CONF_SWITCH_ENTITIES: ["light.dining_room"],
+                CONF_DURATION: "4:00",
+            }
         },
     },
     "invalid_color_string": {


### PR DESCRIPTION
## Summary:
This change adds the ability to control the brightness of a notification without having to write configuration for each LED in the Full LED configuration. If the user does not adjust the brightness, it will be set to the current default of 100%. 

This change addresses issue #24 , which was closed due to inactivity. That said, I'm doing this for my own environment.

Here's how the config screen looks in my environment:
<img width="1280" height="625" alt="chrome_ZJg4Drr53M" src="https://github.com/user-attachments/assets/ff6d32a5-c58a-4726-82b4-a0ea611c06ef" />

