### PR TITLE
Zigbee2MQTT Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ What it can do:
 - **Even more**  
   There are some more goodies in to docs below. Enjoy!
 
-_Note: currently this is limited to Blue switches using ZHA, but ideally Z2M and other Inovelli switches will be added in the future._
+_Note: currently this is limited to Blue switches using ZHA or Zigbee2MQTT, but other Inovelli switches will be added in the future._
 
 **Configure notifications** for multiple switches easily:
 

--- a/custom_components/lampie/config_flow.py
+++ b/custom_components/lampie/config_flow.py
@@ -620,19 +620,19 @@ def _is_inovelli_switch(
     entity_registry: er.EntityRegistry,
     entity_id: str,
 ) -> bool:
-    """Check if entity_id should be included for dependent entities.
+    """Check if entity_id should be included for the list of switches.
 
-    Determine if an entity_id represents an entity with a `state_class` of
-    `total_increasing` and a `unit_of_measurement` of `km`.
+    Determine if an entity_id represents an Inovelli switch.
 
     Returns:
         A flag indicating if the entity should be included.
     """
+
     return bool(
         (entity := entity_registry.async_get(entity_id))
         and (device := device_registry.async_get(entity.device_id))
-        and (model := device.model)
-        and (model in INOVELLI_MODELS)
+        and ((model := device.model), (model_id := device.model_id))
+        and ((model in INOVELLI_MODELS) or (model_id in INOVELLI_MODELS))
     )
 
 

--- a/custom_components/lampie/manifest.json
+++ b/custom_components/lampie/manifest.json
@@ -5,7 +5,7 @@
     "@wbyoung"
   ],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["mqtt"],
   "documentation": "https://github.com/wbyoung/lampie",
   "homekit": {},
   "iot_class": "calculated",

--- a/custom_components/lampie/orchestrator.py
+++ b/custom_components/lampie/orchestrator.py
@@ -6,20 +6,31 @@ from collections.abc import Awaitable, Callable, Sequence
 from contextlib import suppress
 from dataclasses import replace
 import datetime as dt
-from enum import IntEnum
+from enum import Enum, IntEnum, auto
 from functools import partial
 import logging
 import re
 from typing import TYPE_CHECKING, Any, Final, NamedTuple, Protocol, Unpack
 
+from homeassistant.components import mqtt
+from homeassistant.components.mqtt import DOMAIN as MQTT_DOMAIN
+from homeassistant.components.mqtt.models import MqttData
 from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er, event as evt
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    event as evt,
+)
 from homeassistant.helpers.device import (
     async_device_info_to_link_from_entity,
     async_entity_id_to_device_id,
 )
+from homeassistant.helpers.json import json_dumps
 from homeassistant.util import dt as dt_util
+from homeassistant.util.hass_dict import HassKey
+from homeassistant.util.json import json_loads_object
 
 from .const import (
     CONF_END_ACTION,
@@ -33,6 +44,7 @@ from .types import (
     DeviceId,
     Effect,
     ExpirationInfo,
+    Integration,
     LampieNotificationInfo,
     LampieNotificationOptionsDict,
     LampieSwitchInfo,
@@ -42,17 +54,26 @@ from .types import (
     LEDConfigSourceType,
     Slug,
     SwitchId,
+    Z2MSwitchInfo,
+    ZHASwitchInfo,
 )
 
 if TYPE_CHECKING:
     from .coordinator import LampieUpdateCoordinator
 
 type ZHAEventData = dict[str, Any]
+type MQTTDeviceName = str
 
 _LOGGER = logging.getLogger(__name__)
 
 ZHA_DOMAIN: Final = "zha"
+DATA_MQTT: HassKey[MqttData] = HassKey("mqtt")
 ALREADY_EXPIRED: Final = 0
+
+SWITCH_INTEGRATIONS = {
+    ZHA_DOMAIN: Integration.ZHA,
+    MQTT_DOMAIN: Integration.Z2M,
+}
 
 FIRMWARE_SECONDS_MAX = dt.timedelta(seconds=60).total_seconds()
 FIRMWARE_MINUTES_MAX = dt.timedelta(minutes=60).total_seconds()
@@ -63,6 +84,9 @@ CLEAR_CONFIG = LEDConfig(
     effect=Effect.CLEAR,
 )
 
+# the ZHA commands are used as the canonical command representation for this
+# integration. other integrations map their command representation to these
+# before using methods such as `_handle_generic_event`.
 DISMISSAL_COMMANDS = {
     "button_3_double",
     "button_6_double",
@@ -86,6 +110,10 @@ PHYSICAL_DISMISSAL_COMMANDS = {
     "button_6_double",
 }
 
+Z2M_ACTION_TO_COMMAND_MAP = {
+    "config_double": "button_3_double",
+}
+
 
 class _LEDMode(IntEnum):
     ALL = 1
@@ -96,6 +124,16 @@ class _DismissalBlocked(Exception):
     pass
 
 
+class _SwitchKeyType(Enum):
+    DEVICE_ID = auto()
+    MQTT_NAME = auto()  # name from MQTT's discovery `state_topic`
+
+
+class _SwitchKey[T](NamedTuple):
+    type: _SwitchKeyType
+    identifier: T
+
+
 class _StartScriptResult(NamedTuple):
     led_config: tuple[LEDConfig, ...] | None
     block_activation: bool
@@ -104,6 +142,10 @@ class _StartScriptResult(NamedTuple):
 class _EndScriptResult(NamedTuple):
     block_dismissal: bool
     block_next: bool
+
+
+class _UnknownIntegrationError(Exception):
+    pass
 
 
 class _LampieUnmanagedSwitchCoordinator:
@@ -134,24 +176,32 @@ class LampieOrchestrator:
         self._coordinators: dict[Slug, LampieUpdateCoordinator] = {}
         self._notifications: dict[Slug, LampieNotificationInfo] = {}
         self._switches: dict[SwitchId, LampieSwitchInfo] = {}
-        self._device_switches: dict[DeviceId, SwitchId] = {}
-        self._cancel_zha_listener: CALLBACK_TYPE = hass.bus.async_listen(
-            "zha_event",
-            self._handle_zha_event,
-            self._filter_zha_events,
-        )
+        self._switch_ids: dict[_SwitchKey[DeviceId | MQTTDeviceName], SwitchId] = {}
+        self._mqtt_subscriptions: set[str] = set()
+        self._teardown_callbacks: list[CALLBACK_TYPE] = [
+            hass.bus.async_listen(
+                "zha_event",
+                self._handle_zha_event,
+                self._filter_zha_events,
+            )
+        ]
 
-    def add_coordinator(self, coordinator: LampieUpdateCoordinator) -> None:
+    async def add_coordinator(self, coordinator: LampieUpdateCoordinator) -> None:
         self._coordinators[coordinator.slug] = coordinator
-        self._update_references()
+        await self._update_references()
 
-    def remove_coordinator(self, coordinator: LampieUpdateCoordinator) -> None:
+    async def remove_coordinator(self, coordinator: LampieUpdateCoordinator) -> None:
         self._coordinators.pop(coordinator.slug)
-        self._update_references()
+        await self._update_references()
+
+    async def setup(self) -> None:
+        pass
 
     def teardown(self) -> bool:
         if len(self._coordinators) == 0:
-            self._cancel_zha_listener()
+            for callback in self._teardown_callbacks:
+                callback()
+
             for key, expiration in (
                 *((key, info.expiration) for key, info in self._notifications.items()),
                 *((key, info.expiration) for key, info in self._switches.items()),
@@ -161,35 +211,6 @@ class LampieOrchestrator:
         return False
 
     def switch_info(self, switch_id: SwitchId) -> LampieSwitchInfo:
-        if switch_id not in self._switches:
-            entity_registry = er.async_get(self._hass)
-            device_id = async_entity_id_to_device_id(self._hass, switch_id)
-            entity_entries = er.async_entries_for_device(entity_registry, device_id)
-            local_protection_id = None
-            disable_clear_notification_id = None
-
-            _LOGGER.debug(
-                "searching %s related entries: %s",
-                switch_id,
-                [(entry.unique_id, entry.translation_key) for entry in entity_entries],
-            )
-
-            for entity_entry in entity_entries:
-                if entity_entry.translation_key == "local_protection":
-                    local_protection_id = entity_entry.entity_id
-                if (
-                    entity_entry.translation_key
-                    == "disable_clear_notifications_double_tap"
-                ):
-                    disable_clear_notification_id = entity_entry.entity_id
-
-            self._device_switches[device_id] = switch_id
-            self._switches[switch_id] = LampieSwitchInfo(
-                led_config=(),
-                led_config_source=LEDConfigSource(None),
-                local_protection_id=local_protection_id,
-                disable_clear_notification_id=disable_clear_notification_id,
-            )
         return self._switches[switch_id]
 
     def store_switch_info(
@@ -220,6 +241,151 @@ class LampieOrchestrator:
                 source,
                 "off" if _all_clear(config) else "on",
             )
+
+    async def _ensure_switch_setup_completed(self, switch_id: SwitchId) -> None:
+        if switch_id in self._switches:
+            return
+
+        entity_registry = er.async_get(self._hass)
+        device_registry = dr.async_get(self._hass)
+        device_id = async_entity_id_to_device_id(self._hass, switch_id)
+        device = device_registry.async_get(device_id)
+        integration = self._switch_integration(device) if device else None
+        entity_entries = er.async_entries_for_device(entity_registry, device_id)
+
+        if not integration:
+            raise _UnknownIntegrationError
+
+        _LOGGER.debug(
+            "searching %s related entries: %s",
+            switch_id,
+            [
+                (
+                    entry.domain,
+                    entry.platform,
+                    entry.unique_id,
+                    entry.translation_key,
+                )
+                for entry in entity_entries
+            ],
+        )
+
+        integration_info = await {
+            Integration.ZHA: self._zha_switch_setup,
+            Integration.Z2M: self._z2m_switch_setup,
+        }[integration](switch_id, device, entity_entries)
+
+        self._switch_ids[_SwitchKey(_SwitchKeyType.DEVICE_ID, device_id)] = switch_id
+        self._switches[switch_id] = LampieSwitchInfo(
+            integration=integration,
+            integration_info=integration_info,
+            led_config=(),
+            led_config_source=LEDConfigSource(None),
+        )
+
+    async def _zha_switch_setup(  # noqa: PLR6301
+        self,
+        switch_id: SwitchId,  # noqa: ARG002
+        device: dr.DeviceEntry,  # noqa: ARG002
+        entity_entries: list[er.RegistryEntry],
+    ) -> ZHASwitchInfo:
+        local_protection_id = None
+        disable_clear_notification_id = None
+
+        def is_zha_platform(entry: er.RegistryEntry) -> bool:
+            return bool(entry.platform == ZHA_DOMAIN)
+
+        for entity_entry in filter(is_zha_platform, entity_entries):
+            if (
+                entity_entry.domain == SWITCH_DOMAIN
+                and entity_entry.translation_key == "local_protection"
+            ):
+                local_protection_id = entity_entry.entity_id
+                _LOGGER.debug(
+                    "found ZHA local protection entity: %s",
+                    local_protection_id,
+                )
+            if entity_entry.domain == SWITCH_DOMAIN and (
+                entity_entry.translation_key == "disable_clear_notifications_double_tap"
+            ):
+                disable_clear_notification_id = entity_entry.entity_id
+                _LOGGER.debug(
+                    "found ZHA disable clear notification entity: %s",
+                    disable_clear_notification_id,
+                )
+
+        return ZHASwitchInfo(
+            local_protection_id=local_protection_id,
+            disable_clear_notification_id=disable_clear_notification_id,
+        )
+
+    async def _z2m_switch_setup(
+        self,
+        switch_id: SwitchId,
+        device: dr.DeviceEntry,
+        entity_entries: list[er.RegistryEntry],  # noqa: ARG002
+    ) -> Z2MSwitchInfo | None:
+        if not await mqtt.async_wait_for_mqtt_client(self._hass):
+            _LOGGER.error("MQTT integration is not available")
+            return None
+
+        try:
+            full_topic = self._hass.data[DATA_MQTT].debug_info_entities[switch_id][
+                "discovery_data"
+            ]["discovery_payload"]["state_topic"]
+
+            _LOGGER.debug(
+                "found Z2M full topic for switch %s: %s", switch_id, full_topic
+            )
+        except (KeyError, AttributeError):
+            full_topic = f"zigbee2mqtt/{device.name}"
+
+            _LOGGER.warning(
+                "failed to determine MQTT topic from internal HASS state for %s. "
+                "using default of %s from device name",
+                switch_id,
+                full_topic,
+            )
+
+        # pull out the base topic and the device name from the full topic.
+        base_topic, mqtt_device_name = full_topic.rsplit("/", 1)
+
+        self._switch_ids[_SwitchKey(_SwitchKeyType.MQTT_NAME, mqtt_device_name)] = (
+            switch_id
+        )
+
+        # subscribe to the base topic for state updates of `localProtection` and
+        # `doubleTapClearNotifications` as well as the `action` updates for
+        # interaction on switches.
+        if base_topic not in self._mqtt_subscriptions:
+            _LOGGER.debug("subscribing to %s for %s", base_topic, switch_id)
+            self._mqtt_subscriptions.add(base_topic)
+            self._teardown_callbacks.append(
+                await mqtt.async_subscribe(
+                    self._hass,
+                    f"{base_topic}/+",
+                    self._handle_z2m_message,
+                )
+            )
+
+        # request an update to attributes we need to know the value of later.
+        # these will be processed in the event handler.
+        await self._hass.services.async_call(
+            MQTT_DOMAIN,
+            "publish",
+            {
+                "topic": f"{full_topic}/get",
+                "payload": json_dumps(
+                    {
+                        "localProtection": "",
+                        "doubleTapClearNotifications": "",
+                    }
+                ),
+            },
+            blocking=True,
+        )
+
+        return Z2MSwitchInfo(full_topic=full_topic)
 
     def has_notification(self, slug: Slug) -> bool:
         return slug in self._coordinators
@@ -291,6 +457,7 @@ class LampieOrchestrator:
                 or start_action_response.led_config
                 or coordinator.led_config,
                 partial(self._async_handle_notification_expired, slug),
+                has_expiration_messaging=self._any_has_expiration_messaging(switches),
                 log_context=slug,
             ),
         )
@@ -376,6 +543,11 @@ class LampieOrchestrator:
         The switch state will be stored and the physical switch will be updated
         to show the specified configuration.
         """
+
+        # since this may be a switch that's not part of any of the config
+        # entries, we need to start by ensuring it's set up.
+        await self._ensure_switch_setup_completed(switch_id)
+
         from_state = self.switch_info(switch_id)
         is_reset = led_config is None
 
@@ -385,6 +557,9 @@ class LampieOrchestrator:
                 from_state.expiration,
                 led_config or (),
                 partial(self._async_handle_switch_override_expired, switch_id),
+                has_expiration_messaging=self._any_has_expiration_messaging(
+                    [switch_id]
+                ),
                 log_context=f"{led_config_source}",
             ),
         )
@@ -666,11 +841,11 @@ class LampieOrchestrator:
             TRACE, "issue_switch_commands: %s; %s, %s", switch_id, led_mode, led_config
         )
 
-        from_params = [self._switch_command_led_params(led) for led in from_config]
+        from_params = [
+            self._switch_command_led_params(led, switch_id) for led in from_config
+        ]
         device_info = async_device_info_to_link_from_entity(self._hass, switch_id)
-        id_tuple = next(iter(device_info["identifiers"]))
         updated_leds = []
-        ieee = id_tuple[1]
 
         # actually apply the desired changes either for the full LED bar or for
         # individual lights within the bar. only apply changes when needed to
@@ -678,7 +853,7 @@ class LampieOrchestrator:
         # no changes need to be applied if the changes were via the switch
         # firmware since the switch will already have cleared the notification.
         for idx, led in enumerate(led_config):
-            params = self._switch_command_led_params(led)
+            params = self._switch_command_led_params(led, switch_id)
 
             with suppress(IndexError):
                 if params == from_params[idx]:
@@ -690,20 +865,11 @@ class LampieOrchestrator:
                 updated_leds.append(str(idx))
 
             _LOGGER.log(TRACE, "update LED %s command: %r", idx, params)
-            await self._hass.services.async_call(
-                ZHA_DOMAIN,
-                "issue_zigbee_cluster_command",
-                {
-                    "ieee": ieee,
-                    "endpoint_id": 1,
-                    "cluster_id": 64561,
-                    "cluster_type": "in",
-                    "command": int(led_mode),
-                    "command_type": "server",
-                    "params": params,
-                    "manufacturer": 4655,
-                },
-                blocking=True,
+            await self._dispatch_service_command(
+                switch_id=switch_id,
+                device_info=device_info,
+                led_mode=led_mode,
+                params=params,
             )
 
         _LOGGER.debug(
@@ -712,9 +878,88 @@ class LampieOrchestrator:
             "all" if led_mode == _LEDMode.ALL else ", ".join(updated_leds),
         )
 
-    @classmethod
-    def _switch_command_led_params(cls, led: LEDConfig) -> dict[str, Any]:
-        firmware_duration = cls._firmware_duration(led.duration)
+    async def _dispatch_service_command(
+        self,
+        *,
+        switch_id: SwitchId,
+        device_info: dr.DeviceInfo,
+        led_mode: _LEDMode,
+        params: dict[str, Any],
+    ) -> None:
+        switch_info = self.switch_info(switch_id)
+        service_command = {
+            Integration.ZHA: self._zha_service_command,
+            Integration.Z2M: self._z2m_service_command,
+        }[switch_info.integration]
+
+        await service_command(
+            switch_info=switch_info,
+            device_info=device_info,
+            led_mode=led_mode,
+            params=params,
+        )
+
+    async def _zha_service_command(
+        self,
+        *,
+        switch_info: LampieSwitchInfo,  # noqa: ARG002
+        device_info: dr.DeviceInfo,
+        led_mode: _LEDMode,
+        params: dict[str, Any],
+    ) -> None:
+        id_tuple = next(iter(device_info["identifiers"]))
+        ieee = id_tuple[1]
+
+        _LOGGER.log(TRACE, "zha.issue_zigbee_cluster_command: %s", led_mode)
+        await self._hass.services.async_call(
+            ZHA_DOMAIN,
+            "issue_zigbee_cluster_command",
+            {
+                "ieee": ieee,
+                "endpoint_id": 1,
+                "cluster_id": 64561,
+                "cluster_type": "in",
+                "command": int(led_mode),
+                "command_type": "server",
+                "params": params,
+                "manufacturer": 4655,
+            },
+            blocking=True,
+        )
+
+    async def _z2m_service_command(
+        self,
+        *,
+        switch_info: LampieSwitchInfo,
+        device_info: dr.DeviceInfo,  # noqa: ARG002
+        led_mode: _LEDMode,
+        params: dict[str, Any],
+    ) -> None:
+        command = (
+            "individual_led_effect" if led_mode == _LEDMode.INDIVIDUAL else "led_effect"
+        )
+        zha_info = switch_info.integration_info
+        topic = f"{zha_info.full_topic}/set"
+
+        _LOGGER.log(TRACE, "mqtt.publish: %s", topic)
+        await self._hass.services.async_call(
+            MQTT_DOMAIN,
+            "publish",
+            {
+                "topic": topic,
+                "payload": json_dumps({command: params}),
+            },
+            blocking=True,
+        )
+
+    def _switch_command_led_params(
+        self, led: LEDConfig, switch_id: SwitchId
+    ) -> dict[str, Any]:
+        firmware_duration = (
+            self._firmware_duration(led.duration)
+            if self._any_has_expiration_messaging([switch_id])
+            else None
+        )
 
         return {
             "led_color": int(led.color),
@@ -727,8 +972,79 @@ class LampieOrchestrator:
             else firmware_duration,
         }
 
-    @classmethod
-    def _firmware_duration(cls, seconds: int | None) -> int | None:
+    def _local_protection_enabled(self, switch_id: SwitchId) -> bool:
+        switch_info = self.switch_info(switch_id)
+        integration = switch_info.integration
+        integration_info = switch_info.integration_info
+
+        assert integration_info is not None, (
+            f"missing integration info for switch {switch_id}"
+        )
+
+        def _zha() -> bool:
+            zha_info: ZHASwitchInfo = integration_info
+
+            return bool(
+                local_protection_id := zha_info.local_protection_id
+            ) and self._hass.states.is_state(local_protection_id, "on")
+
+        def _z2m() -> bool:
+            z2m_info: Z2MSwitchInfo = integration_info
+            return bool(z2m_info.local_protection_enabled)
+
+        return {
+            Integration.ZHA: _zha,
+            Integration.Z2M: _z2m,
+        }[integration]()
+
+    def _double_tap_clear_notifications_disabled(self, switch_id: SwitchId) -> bool:
+        switch_info = self.switch_info(switch_id)
+        integration = switch_info.integration
+        integration_info = switch_info.integration_info
+
+        assert integration_info is not None, (
+            f"missing integration info for switch {switch_id}"
+        )
+
+        def _zha() -> bool:
+            zha_info: ZHASwitchInfo = integration_info
+
+            return bool(
+                disable_clear_notification_id := zha_info.disable_clear_notification_id
+            ) and self._hass.states.is_state(disable_clear_notification_id, "on")
+
+        def _z2m() -> bool:
+            z2m_info: Z2MSwitchInfo = integration_info
+            return bool(z2m_info.double_tap_clear_notifications_disabled)
+
+        return {
+            Integration.ZHA: _zha,
+            Integration.Z2M: _z2m,
+        }[integration]()
+
+    def _any_has_expiration_messaging(self, switches: Sequence[SwitchId]) -> bool:
+        """Check if any switch via an integration that sends expiration events.
+
+        All Inovelli Blue series switches send Zigbee messages for notifications
+        expiring (when local protection is not enabled). However, integrations
+        currently handle them differently:
+            ZHA: Processes these and turns them into
+                `led_effect_complete_{ALL|LED_1-7}` commands.
+            Z2M: Processes these and turns them into
+                `{"notificationComplete": "{ALL|LED_1-7}"}` messages.
+
+        Returns:
+            A boolean indicating if any of the switches are part of such an
+                integration.
+        """
+        return any(
+            self.switch_info(switch_id).integration
+            in {Integration.ZHA, Integration.Z2M}
+            for switch_id in switches
+        )
+
+    @staticmethod
+    def _firmware_duration(seconds: int | None) -> int | None:
         """Convert a timeframe to a duration supported by the switch firmware.
 
         Args:
@@ -753,17 +1069,100 @@ class LampieOrchestrator:
         self,
         event_data: ZHAEventData,
     ) -> bool:
+        switch_key = _SwitchKey(_SwitchKeyType.DEVICE_ID, event_data["device_id"])
         return (
-            event_data["device_id"] in self._device_switches
+            switch_key in self._switch_ids
             and event_data["command"] in DISMISSAL_COMMANDS
         )
 
     @callback
     async def _handle_zha_event(self, event: Event[ZHAEventData]) -> None:
-        hass = self._hass
-        command = event.data["command"]
         device_id = event.data["device_id"]
-        switch_id = self._device_switches[device_id]
+        switch_key = _SwitchKey(_SwitchKeyType.DEVICE_ID, device_id)
+        switch_id = self._switch_ids[switch_key]
+        await self._handle_generic_event(
+            command=event.data["command"],
+            switch_id=switch_id,
+            integration=Integration.ZHA,
+        )
+
+    @callback
+    async def _handle_z2m_message(self, message: mqtt.ReceiveMessage) -> None:
+        _LOGGER.log(TRACE, "handling mqtt message: %s", message)
+
+        _, mqtt_device_name = message.topic.rsplit("/", 1)
+        switch_key = _SwitchKey(_SwitchKeyType.MQTT_NAME, mqtt_device_name)
+        switch_id = self._switch_ids.get(switch_key)
+
+        # ignore the message if it's not related to a switch in the system
+        if switch_id is None:
+            return
+
+        switch_info = self.switch_info(switch_id)
+        zha_info = switch_info.integration_info
+        zha_info_changed = False
+
+        # ignore the message if for some reason there's a topic mismatch, i.e.
+        # two devices named with different base topics.
+        if message.topic != zha_info.full_topic:
+            return
+
+        # wait to parse the payload until the above checks are performed to avoid
+        # the overhead of parsing messages we won't handle.
+        payload = json_loads_object(message.payload)
+
+        # if this is for a valid action, dispatch it to the generic event handler
+        if (action := payload.get("action")) and (
+            command := Z2M_ACTION_TO_COMMAND_MAP.get(action)
+        ):
+            await self._handle_generic_event(
+                command=command,
+                switch_id=switch_id,
+                integration=Integration.Z2M,
+            )
+
+        if (
+            (notification_complete := payload.get("notificationComplete"))
+            and (command := f"led_effect_complete_{notification_complete}")
+            and command in DISMISSAL_COMMANDS
+        ):
+            await self._handle_generic_event(
+                command=command,
+                switch_id=switch_id,
+                integration=Integration.Z2M,
+            )
+
+        if "localProtection" in payload:
+            zha_info_changed = True
+            zha_info = replace(
+                zha_info,
+                local_protection_enabled=payload["localProtection"].lower()
+                in {"enabled", "enabled (default)"},
+            )
+
+        if "doubleTapClearNotifications" in payload:
+            zha_info_changed = True
+            zha_info = replace(
+                zha_info,
+                double_tap_clear_notifications_disabled=payload[
+                    "doubleTapClearNotifications"
+                ].lower()
+                == "disabled",
+            )
+
+        if zha_info_changed:
+            self.store_switch_info(
+                switch_id,
+                integration_info=zha_info,
+            )
+
+    async def _handle_generic_event(
+        self,
+        *,
+        command: str,
+        switch_id: SwitchId,
+        integration: Integration,
+    ) -> None:
         from_state = self.switch_info(switch_id)
         led_config_source = from_state.led_config_source
         led_config = [*from_state.led_config]
@@ -775,14 +1174,17 @@ class LampieOrchestrator:
         if not led_config or not led_config_source:
             _LOGGER.warning(
                 "missing LED config and/or source for dismissal on switch %s; "
-                "skipping processing ZHA event %s",
+                "skipping processing %s event %s",
                 switch_id,
+                str(integration).upper(),
                 command,
                 stack_info=True,
             )
             return
 
-        _LOGGER.debug("processing ZHA event %s on %s", command, switch_id)
+        _LOGGER.debug(
+            "processing %s event %s on %s", str(integration).upper(), command, switch_id
+        )
 
         if match := re.search(r"_LED_(\d+)$", command):
             index = int(match[1]) - 1
@@ -806,15 +1208,9 @@ class LampieOrchestrator:
             all_clear = True
 
         if all_clear and command in CONFIGURABLE_COMMANDS:
-            switch_info = self.switch_info(switch_id)
-            local_protection = switch_info.local_protection_id and hass.states.is_state(
-                switch_info and switch_info.local_protection_id, "on"
-            )
-            disable_clear_notification = (
-                switch_info.disable_clear_notification_id
-                and hass.states.is_state(
-                    switch_info.disable_clear_notification_id, "on"
-                )
+            local_protection = self._local_protection_enabled(switch_id)
+            disable_clear_notification = self._double_tap_clear_notifications_disabled(
+                switch_id
             )
 
             is_valid_dismissal = not disable_clear_notification
@@ -1018,6 +1414,9 @@ class LampieOrchestrator:
                     led_config,
                     handle_expired,
                     is_starting=False,
+                    has_expiration_messaging=self._any_has_expiration_messaging(
+                        switches
+                    ),
                     log_context=f"partial-expiry {log_context}",
                 ),
             )
@@ -1044,6 +1443,7 @@ class LampieOrchestrator:
         callback: _ExpirationHandler,
         *,
         is_starting: bool = True,
+        has_expiration_messaging: bool,
         log_context: str,
     ) -> ExpirationInfo:
         started_at = expiration.started_at
@@ -1060,7 +1460,10 @@ class LampieOrchestrator:
             for item in led_config
             if item.duration is not None
             and item.duration != ALREADY_EXPIRED
-            and self._firmware_duration(item.duration) is None
+            and (
+                not has_expiration_messaging
+                or self._firmware_duration(item.duration) is None
+            )
         ]
         duration: int | None = min(durations) if durations else None
 
@@ -1105,7 +1508,7 @@ class LampieOrchestrator:
 
         return expiration
 
-    def _update_references(self) -> None:
+    async def _update_references(self) -> None:
         processed_slugs: list[Slug] = []
         processed_switches: set[SwitchId] = set()
 
@@ -1118,8 +1521,18 @@ class LampieOrchestrator:
             )
 
             for switch_id in switch_ids:
+                try:
+                    await self._ensure_switch_setup_completed(switch_id)
+                except _UnknownIntegrationError:
+                    _LOGGER.exception(
+                        "ignoring switch %s: could not to a valid integration",
+                        switch_id,
+                    )
+                    continue
+
+                switch_info = self.switch_info(switch_id)
                 priorities = switch_priorities.get(switch_id) or [slug]
-                expected = [*self.switch_info(switch_id).priorities]
+                expected = [*switch_info.priorities]
 
                 if switch_id in processed_switches and expected != priorities:
                     _LOGGER.warning(
@@ -1137,12 +1550,18 @@ class LampieOrchestrator:
                     continue
 
                 self._switches[switch_id] = replace(
-                    self.switch_info(switch_id),
+                    switch_info,
                     priorities=tuple(priorities),
                 )
                 processed_switches.add(switch_id)
 
             processed_slugs.append(slug)
+
+    @classmethod
+    def _switch_integration(cls, device: dr.DeviceEntry) -> Integration | None:
+        id_tuple = next(iter(device.identifiers))
+        domain = id_tuple[0]
+        return SWITCH_INTEGRATIONS.get(domain)
 
 
 def _all_clear(led_config: Sequence[LEDConfig]) -> bool:

--- a/custom_components/lampie/orchestrator.py
+++ b/custom_components/lampie/orchestrator.py
@@ -110,6 +110,14 @@ PHYSICAL_DISMISSAL_COMMANDS = {
     "button_6_double",
 }
 
+_ZHA_PARAM_KEYS = {
+    "color": "led_color",
+    "effect": "led_effect",
+    "level": "led_level",
+    "duration": "led_duration",
+    "led": "led_number",
+}
+
 Z2M_ACTION_TO_COMMAND_MAP = {
     "config_double": "button_3_double",
 }
@@ -861,7 +869,7 @@ class LampieOrchestrator:
                     continue
 
             if led_mode == _LEDMode.INDIVIDUAL:
-                params["led_number"] = idx
+                params["led"] = idx
                 updated_leds.append(str(idx))
 
             _LOGGER.log(TRACE, "update LED %s command: %r", idx, params)
@@ -909,6 +917,7 @@ class LampieOrchestrator:
     ) -> None:
         id_tuple = next(iter(device_info["identifiers"]))
         ieee = id_tuple[1]
+        zha_params = {_ZHA_PARAM_KEYS[k]: v for k, v in params.items()}
 
         _LOGGER.log(TRACE, "zha.issue_zigbee_cluster_command: %s", led_mode)
         await self._hass.services.async_call(
@@ -921,7 +930,7 @@ class LampieOrchestrator:
                 "cluster_type": "in",
                 "command": int(led_mode),
                 "command_type": "server",
-                "params": params,
+                "params": zha_params,
                 "manufacturer": 4655,
             },
             blocking=True,
@@ -962,10 +971,10 @@ class LampieOrchestrator:
         )
 
         return {
-            "led_color": int(led.color),
-            "led_effect": led.effect.value,
-            "led_level": int(led.brightness),
-            "led_duration": 255
+            "color": int(led.color),
+            "effect": led.effect.value,
+            "level": int(led.brightness),
+            "duration": 255
             if led.duration is None
             or led.duration == ALREADY_EXPIRED
             or firmware_duration is None

--- a/custom_components/lampie/orchestrator.py
+++ b/custom_components/lampie/orchestrator.py
@@ -118,6 +118,46 @@ _ZHA_PARAM_KEYS = {
     "led": "led_number",
 }
 
+# Z2M's Inovelli converter expects effect as a string name and does its own
+# lookup into these tables; sending the raw integer makes the converter drop
+# the value and reject the command with "Parameter 'effect' is missing".
+# Verbatim from zigbee-herdsman-converters/src/lib/inovelli.ts.
+_Z2M_LED_EFFECT_NAMES = {
+    0: "off",
+    1: "solid",
+    2: "fast_blink",
+    3: "slow_blink",
+    4: "pulse",
+    5: "chase",
+    6: "open_close",
+    7: "small_to_big",
+    8: "aurora",
+    9: "slow_falling",
+    10: "medium_falling",
+    11: "fast_falling",
+    12: "slow_rising",
+    13: "medium_rising",
+    14: "fast_rising",
+    15: "medium_blink",
+    16: "slow_chase",
+    17: "fast_chase",
+    18: "fast_siren",
+    19: "slow_siren",
+    255: "clear_effect",
+}
+_Z2M_INDIVIDUAL_LED_EFFECT_NAMES = {
+    0: "off",
+    1: "solid",
+    2: "fast_blink",
+    3: "slow_blink",
+    4: "pulse",
+    5: "chase",
+    6: "falling",
+    7: "rising",
+    8: "aurora",
+    255: "clear_effect",
+}
+
 Z2M_ACTION_TO_COMMAND_MAP = {
     "config_double": "button_3_double",
 }
@@ -947,6 +987,12 @@ class LampieOrchestrator:
         command = (
             "individual_led_effect" if led_mode == _LEDMode.INDIVIDUAL else "led_effect"
         )
+        effect_names = (
+            _Z2M_INDIVIDUAL_LED_EFFECT_NAMES
+            if led_mode == _LEDMode.INDIVIDUAL
+            else _Z2M_LED_EFFECT_NAMES
+        )
+        z2m_params = {**params, "effect": effect_names[params["effect"]]}
         zha_info = switch_info.integration_info
         topic = f"{zha_info.full_topic}/set"
 
@@ -956,7 +1002,7 @@ class LampieOrchestrator:
             "publish",
             {
                 "topic": topic,
-                "payload": json_dumps({command: params}),
+                "payload": json_dumps({command: z2m_params}),
             },
             blocking=True,
         )

--- a/custom_components/lampie/services.yaml
+++ b/custom_components/lampie/services.yaml
@@ -16,10 +16,14 @@ override:
         entity:
           multiple: true
           filter:
-            integration: zha
-            domain:
-              - light
-              - fan
+            - integration: zha
+              domain:
+                - light
+                - fan
+            - integration: mqtt
+              domain:
+                - light
+                - fan
     leds:
       required: true
       selector:

--- a/custom_components/lampie/types.py
+++ b/custom_components/lampie/types.py
@@ -245,6 +245,13 @@ class InvalidColor(Exception):
     index: int | None = None
 
 
+class Integration(StrEnum):
+    """Switch integration type."""
+
+    ZHA = auto()
+    Z2M = auto()
+
+
 @dataclass(frozen=True)
 class ExpirationInfo:
     """Storage of expiration info."""
@@ -272,13 +279,30 @@ class LampieNotificationOptionsDict(TypedDict):
 
 
 @dataclass(frozen=True)
+class ZHASwitchInfo:
+    """ZHA switch info data class."""
+
+    local_protection_id: EntityId | None = None
+    disable_clear_notification_id: EntityId | None = None
+
+
+@dataclass(frozen=True)
+class Z2MSwitchInfo:
+    """Z2M switch info data class."""
+
+    full_topic: str
+    local_protection_enabled: bool | None = None
+    double_tap_clear_notifications_disabled: bool | None = None
+
+
+@dataclass(frozen=True)
 class LampieSwitchInfo:
     """Lampie switch data class."""
 
     led_config: tuple[LEDConfig, ...]
     led_config_source: LEDConfigSource
-    local_protection_id: EntityId | None = None
-    disable_clear_notification_id: EntityId | None = None
+    integration_info: Any
+    integration: Integration = Integration.ZHA
     priorities: tuple[Slug, ...] = field(default_factory=tuple)
     expiration: ExpirationInfo = field(default_factory=ExpirationInfo)
 
@@ -288,8 +312,7 @@ class LampieSwitchOptionsDict(TypedDict):
 
     led_config: NotRequired[tuple[LEDConfig, ...]]
     led_config_source: NotRequired[LEDConfigSource]
-    local_protection_id: NotRequired[EntityId | None]
-    disable_clear_notification_id: NotRequired[EntityId | None]
+    integration_info: NotRequired[Any | None]
     priorities: NotRequired[tuple[Slug, ...]]
     expiration: NotRequired[ExpirationInfo]
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,8 +14,12 @@ from pytest_homeassistant_custom_component.common import (
     async_fire_time_changed,
 )
 
+from custom_components.lampie.orchestrator import DATA_MQTT
+from custom_components.lampie.types import Integration
+
 ZHA_DOMAIN = "zha"
 MOCK_UTC_NOW = dt.datetime(2025, 5, 20, 10, 51, 32, 3245, tzinfo=dt.UTC)
+MOCK_Z2M_DEVICE_ID = "mock-z2m-device-name"  # note: in a real system, this is in the format 0x0000000000000000
 
 
 class _ANY:
@@ -53,7 +57,11 @@ async def setup_added_integration(
 
 
 def add_mock_switch(
-    hass, entity_id, device_attrs: dict[str, Any] | None = None
+    hass,
+    entity_id,
+    device_attrs: dict[str, Any] | None = None,
+    *,
+    integration: Integration = Integration.ZHA,
 ) -> er.RegistryEntry:
     """Add a switch device and (some) related entities.
 
@@ -61,41 +69,87 @@ def add_mock_switch(
         The created switch entity.
     """
     domain, object_id = entity_id.split(".")
+
+    integration_domain = {
+        Integration.ZHA: "zha",
+        Integration.Z2M: "mqtt",
+    }[integration]
+
+    identifiers = {
+        Integration.ZHA: ("zha", f"mock-ieee:{object_id}"),
+        Integration.Z2M: ("mqtt", f"{MOCK_Z2M_DEVICE_ID}_{object_id}"),
+    }[integration]
+
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
     mock_config_entry = MockConfigEntry(
-        title=" ".join(object_id.capitalize().split("_")), domain=ZHA_DOMAIN, data={}
+        title=" ".join(object_id.capitalize().split("_")),
+        domain=integration_domain,
+        data={},
     )
     mock_config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
         name=mock_config_entry.title,
         config_entry_id=mock_config_entry.entry_id,
-        identifiers={(ZHA_DOMAIN, f"mock-ieee:{object_id}")},
+        identifiers={identifiers},
         **(device_attrs or {}),
     )
     switch = entity_registry.async_get_or_create(
         domain,
-        ZHA_DOMAIN,
+        integration_domain,
         object_id,
         suggested_object_id=object_id,
         device_id=device_entry.id,
     )
-    entity_registry.async_get_or_create(
-        "switch",
-        ZHA_DOMAIN,
-        f"{object_id}-local_protection",
-        suggested_object_id=f"{object_id}_local_protection",
-        translation_key="local_protection",
-        device_id=device_entry.id,
-    )
-    entity_registry.async_get_or_create(
-        "switch",
-        ZHA_DOMAIN,
-        f"{object_id}-disable_clear_notifications_double_tap",
-        suggested_object_id=f"{object_id}_disable_config_2x_tap_to_clear_notifications",
-        translation_key="disable_clear_notifications_double_tap",
-        device_id=device_entry.id,
-    )
+
+    if integration == Integration.ZHA:
+        entity_registry.async_get_or_create(
+            "switch",
+            integration_domain,
+            f"{object_id}-local_protection",
+            suggested_object_id=f"{object_id}_local_protection",
+            translation_key="local_protection",
+            device_id=device_entry.id,
+        )
+        entity_registry.async_get_or_create(
+            "switch",
+            integration_domain,
+            f"{object_id}-disable_clear_notifications_double_tap",
+            suggested_object_id=f"{object_id}_disable_config_2x_tap_to_clear_notifications",
+            translation_key="disable_clear_notifications_double_tap",
+            device_id=device_entry.id,
+        )
+
+    if integration == Integration.Z2M:
+        entity_registry.async_get_or_create(
+            "select",
+            integration_domain,
+            f"{MOCK_Z2M_DEVICE_ID}_localProtection_zigbee2mqtt",
+            suggested_object_id=f"{object_id}_localProtection",  # note: not part of real Z2M setup
+            original_name="LocalProtection",
+            capabilities={
+                "options": ["Disabled", "Enabled"],
+            },
+            device_id=device_entry.id,
+        )
+        entity_registry.async_get_or_create(
+            "select",
+            integration_domain,
+            f"{MOCK_Z2M_DEVICE_ID}_doubleTapClearNotifications_zigbee2mqtt",
+            suggested_object_id=f"{object_id}_doubleTapClearNotifications",  # note: not part of real Z2M setup
+            original_name="DoubleTapClearNotifications",
+            capabilities={
+                "options": ["Enabled (Default)", "Disabled"],
+            },
+            device_id=device_entry.id,
+        )
+
+        # set a custom base topic for this. the default is `zigbee2mqtt` and
+        # here it's changed to `home/z2m`.
+        hass.data[DATA_MQTT].debug_info_entities[entity_id]["discovery_data"][
+            "discovery_payload"
+        ]["state_topic"] = f"home/z2m/{mock_config_entry.title}"
+
     return switch
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 """Fixtures for testing."""
 
+from collections import defaultdict
+from collections.abc import Generator
 import logging
+from unittest.mock import AsyncMock, Mock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from homeassistant.core import HomeAssistant
@@ -16,6 +19,8 @@ from custom_components.lampie.const import (
     DOMAIN,
     TRACE,
 )
+from custom_components.lampie.orchestrator import DATA_MQTT
+from custom_components.lampie.types import Integration
 
 from . import MOCK_UTC_NOW, MockNow, add_mock_switch, setup_integration
 from .syrupy import LampieSnapshotExtension
@@ -52,6 +57,59 @@ def auto_enable_custom_integrations(enable_custom_integrations):
     return
 
 
+@pytest.fixture(name="mqtt", autouse=True)
+def auto_patch_mqtt(
+    hass: HomeAssistant,
+) -> Generator[dict[str, Mock | AsyncMock]]:
+    """Patch mqtt helpers and integration setup/teardown."""
+    mock_unsubscribe = Mock()
+
+    with (
+        patch(
+            "homeassistant.components.mqtt.async_wait_for_mqtt_client",
+            return_value=True,
+        ) as mock_wait_for_mqtt_client,
+        patch(
+            "homeassistant.components.mqtt.async_subscribe",
+            return_value=mock_unsubscribe,
+        ) as mock_subscribe,
+        patch(
+            "homeassistant.components.mqtt.async_setup", return_value=True
+        ) as mock_setup,
+        patch(
+            "homeassistant.components.mqtt.async_setup_entry", return_value=True
+        ) as mock_setup_entry,
+        patch(
+            "homeassistant.components.mqtt.async_unload_entry", return_value=True
+        ) as mock_unload_entry,
+    ):
+
+        def infinite_defaultdict():
+            return defaultdict(infinite_defaultdict)
+
+        mock = Mock()
+        mock.debug_info_entities = infinite_defaultdict()
+        hass.data[DATA_MQTT] = mock
+
+        yield {
+            "subscribe": mock_subscribe,
+            "unsubscribe": mock_unsubscribe,
+            "wait_for_mqtt_client": mock_wait_for_mqtt_client,
+            "setup": mock_setup,
+            "setup_entry": mock_setup_entry,
+            "unload_entry": mock_unload_entry,
+        }
+
+        hass.data.pop(DATA_MQTT)
+
+
+@pytest.fixture(name="mqtt_subscribe")
+def patch_mqtt_async_subscribe(  # noqa: FURB118
+    mqtt: dict[str, Mock | AsyncMock],
+) -> Generator[dict[str, Mock | AsyncMock]]:
+    return mqtt["subscribe"]
+
+
 @pytest.fixture
 def snapshot(snapshot: SnapshotAssertion) -> SnapshotAssertion:
     """Return snapshot assertion fixture with the Home Assistant extension."""
@@ -84,11 +142,25 @@ def mock_config_entry() -> MockConfigEntry:
     )
 
 
+@pytest.fixture(name="integration_domain")
+def mock_integration_domain() -> Integration:
+    """Return the default mocked integration domain."""
+    return Integration.ZHA
+
+
 @pytest.fixture(name="switch")
-def mock_switch(hass: HomeAssistant) -> er.RegistryEntry:
+def mock_switch(
+    hass: HomeAssistant, integration_domain: Integration
+) -> er.RegistryEntry:
     """Return the default mocked config entry."""
+
+    model_key = "model_id" if integration_domain == Integration.Z2M else "model"
+
     return add_mock_switch(
-        hass, "light.kitchen", {"manufacturer": "Inovelli", "model": "VZM31-SN"}
+        hass,
+        "light.kitchen",
+        {"manufacturer": "Inovelli", model_key: "VZM31-SN"},
+        integration=integration_domain,
     )
 
 

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -86,10 +86,14 @@
     }),
     'switches': dict({
       'light.kitchen': dict({
-        'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
         'expiration': dict({
           'cancel_listener': None,
           'started_at': None,
+        }),
+        'integration': 'zha',
+        'integration_info': dict({
+          'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+          'local_protection_id': 'switch.kitchen_local_protection',
         }),
         'led_config': list([
           dict({
@@ -106,7 +110,6 @@
           'type': 'notification',
           'value': 'doors_open',
         }),
-        'local_protection_id': 'switch.kitchen_local_protection',
         'priorities': list([
           'doors_open',
         ]),

--- a/tests/snapshots/test_scenarios.ambr
+++ b/tests/snapshots/test_scenarios.ambr
@@ -136,11 +136,15 @@
 # ---
 # name: test_dismissal_from_switch[aux_double_press_dismiss_higher_priority_updates_to_display_original][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
       dict({
@@ -154,7 +158,6 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': 'doors_open',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'medicine',
       'doors_open',
@@ -490,11 +493,15 @@
 # ---
 # name: test_dismissal_from_switch[config_double_press_dismiss_higher_priority_updates_to_display_original][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
       dict({
@@ -508,7 +515,6 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': 'doors_open',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'medicine',
       'doors_open',
@@ -741,7 +747,7 @@
   list([
   ])
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_5m1s_duration_expired][events]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_5m1s_duration_expired][events]
   list([
     EventSnapshot({
       'context': <ANY>,
@@ -756,7 +762,7 @@
     }),
   ])
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_5m1s_duration_expired][notification_info]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_5m1s_duration_expired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -767,7 +773,7 @@
     'notification_on': True,
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_brightness]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -783,7 +789,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_color]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -797,7 +803,7 @@
     'state': 'red',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_duration]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -813,7 +819,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_type]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -827,7 +833,7 @@
     'state': 'open_close',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_notification]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -841,11 +847,11 @@
     'state': 'doors_open',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_5m1s_duration_expired][service_calls]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_5m1s_duration_expired][service_calls]
   list([
   ])
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_5m1s_duration_expired][switch.doors_open_notification]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_5m1s_duration_expired][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -859,13 +865,18 @@
     'state': 'on',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_5m1s_duration_expired][switch_info]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_5m1s_duration_expired][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
       dict({
@@ -879,83 +890,60 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': 'doors_open',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_5m1s_duration_expired][zha_cluster_commands]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_5m1s_duration_expired][z2m_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 0,
-          'led_duration': 255,
-          'led_effect': 6,
-          'led_level': 100,
-        }),
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
     }),
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 90,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-        }),
+        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
     }),
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 0,
-          'led_duration': 255,
-          'led_effect': 6,
-          'led_level': 100,
-        }),
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
     }),
   ])
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_dismissed][events]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_dismissed][events]
   list([
     EventSnapshot({
       'context': <ANY>,
@@ -970,7 +958,7 @@
     }),
   ])
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_dismissed][notification_info]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_dismissed][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -981,7 +969,7 @@
     'notification_on': True,
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_brightness]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -997,7 +985,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_color]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -1011,7 +999,7 @@
     'state': 'red',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_duration]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -1027,7 +1015,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_type]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -1041,7 +1029,7 @@
     'state': 'open_close',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_notification]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -1055,11 +1043,11 @@
     'state': 'doors_open',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_dismissed][service_calls]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_dismissed][service_calls]
   list([
   ])
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_dismissed][switch.doors_open_notification]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_dismissed][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -1073,14 +1061,19 @@
     'state': 'on',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_dismissed][switch_info]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_dismissed][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
     }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
+    }),
     'led_config': tuple(
       dict({
         'brightness': 100.0,
@@ -1093,83 +1086,60 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': 'doors_open',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_dismissed][zha_cluster_commands]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_dismissed][z2m_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 0,
-          'led_duration': 255,
-          'led_effect': 6,
-          'led_level': 100,
-        }),
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
     }),
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 90,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-        }),
+        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
     }),
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 0,
-          'led_duration': 255,
-          'led_effect': 6,
-          'led_level': 100,
-        }),
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
     }),
   ])
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_reset][notification_info]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_reset][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -1180,7 +1150,7 @@
     'notification_on': True,
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_brightness]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -1196,7 +1166,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_color]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -1210,7 +1180,7 @@
     'state': 'red',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_duration]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -1226,7 +1196,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_type]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -1240,7 +1210,7 @@
     'state': 'open_close',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_reset][sensor.kitchen_notification]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_reset][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -1254,11 +1224,11 @@
     'state': 'doors_open',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_reset][service_calls]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_reset][service_calls]
   list([
   ])
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_reset][switch.doors_open_notification]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_reset][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -1272,13 +1242,18 @@
     'state': 'on',
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_reset][switch_info]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_reset][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
       dict({
@@ -1292,83 +1267,60 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': 'doors_open',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_enable_notification_with_switch_override[doors_open_on,kitchen_override_leds_reset][zha_cluster_commands]
+# name: test_enable_notification_with_switch_override[z2m-doors_open_on,kitchen_override_leds_reset][z2m_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 0,
-          'led_duration': 255,
-          'led_effect': 6,
-          'led_level': 100,
-        }),
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
     }),
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 90,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-        }),
+        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
     }),
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 0,
-          'led_duration': 255,
-          'led_effect': 6,
-          'led_level': 100,
-        }),
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
     }),
   ])
 # ---
-# name: test_enable_notification_with_switch_override[kitchen_override,doors_open_on][notification_info]
+# name: test_enable_notification_with_switch_override[z2m-kitchen_override,doors_open_on][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -1379,7 +1331,7 @@
     'notification_on': True,
   })
 # ---
-# name: test_enable_notification_with_switch_override[kitchen_override,doors_open_on][sensor.kitchen_effect_brightness]
+# name: test_enable_notification_with_switch_override[z2m-kitchen_override,doors_open_on][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -1395,7 +1347,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_enable_notification_with_switch_override[kitchen_override,doors_open_on][sensor.kitchen_effect_color]
+# name: test_enable_notification_with_switch_override[z2m-kitchen_override,doors_open_on][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -1409,7 +1361,7 @@
     'state': 'green',
   })
 # ---
-# name: test_enable_notification_with_switch_override[kitchen_override,doors_open_on][sensor.kitchen_effect_duration]
+# name: test_enable_notification_with_switch_override[z2m-kitchen_override,doors_open_on][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -1425,7 +1377,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_enable_notification_with_switch_override[kitchen_override,doors_open_on][sensor.kitchen_effect_type]
+# name: test_enable_notification_with_switch_override[z2m-kitchen_override,doors_open_on][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -1439,7 +1391,7 @@
     'state': 'solid',
   })
 # ---
-# name: test_enable_notification_with_switch_override[kitchen_override,doors_open_on][sensor.kitchen_notification]
+# name: test_enable_notification_with_switch_override[z2m-kitchen_override,doors_open_on][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -1453,11 +1405,11 @@
     'state': 'lampie.override',
   })
 # ---
-# name: test_enable_notification_with_switch_override[kitchen_override,doors_open_on][service_calls]
+# name: test_enable_notification_with_switch_override[z2m-kitchen_override,doors_open_on][service_calls]
   list([
   ])
 # ---
-# name: test_enable_notification_with_switch_override[kitchen_override,doors_open_on][switch.doors_open_notification]
+# name: test_enable_notification_with_switch_override[z2m-kitchen_override,doors_open_on][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -1471,13 +1423,18 @@
     'state': 'on',
   })
 # ---
-# name: test_enable_notification_with_switch_override[kitchen_override,doors_open_on][switch_info]
+# name: test_enable_notification_with_switch_override[z2m-kitchen_override,doors_open_on][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
       dict({
@@ -1491,13 +1448,806 @@
       'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'lampie.override',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_enable_notification_with_switch_override[kitchen_override,doors_open_on][zha_cluster_commands]
+# name: test_enable_notification_with_switch_override[z2m-kitchen_override,doors_open_on][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_5m1s_duration_expired][events]
+  list([
+    EventSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'entity_id': 'light.kitchen',
+        'override': 'lampie.override',
+      }),
+      'event_type': 'lampie.expired',
+      'id': <ANY>,
+      'origin': 'LOCAL',
+      'time_fired': <ANY>,
+    }),
+  ])
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_5m1s_duration_expired][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'led_config_override': None,
+    'notification_on': True,
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'red',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open_close',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'doors_open',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_5m1s_duration_expired][service_calls]
+  list([
+  ])
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_5m1s_duration_expired][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_5m1s_duration_expired][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.RED: 0>,
+        'duration': None,
+        'effect': <Effect.OPEN_CLOSE: 6>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': 'doors_open',
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_5m1s_duration_expired][zha_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 0,
+          'led_duration': 255,
+          'led_effect': 6,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 90,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 0,
+          'led_duration': 255,
+          'led_effect': 6,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+  ])
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_dismissed][events]
+  list([
+    EventSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'entity_id': 'light.kitchen',
+        'override': 'lampie.override',
+      }),
+      'event_type': 'lampie.dismissed',
+      'id': <ANY>,
+      'origin': 'LOCAL',
+      'time_fired': <ANY>,
+    }),
+  ])
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_dismissed][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'led_config_override': None,
+    'notification_on': True,
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'red',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open_close',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_dismissed][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'doors_open',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_dismissed][service_calls]
+  list([
+  ])
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_dismissed][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_dismissed][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.RED: 0>,
+        'duration': None,
+        'effect': <Effect.OPEN_CLOSE: 6>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': 'doors_open',
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_dismissed][zha_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 0,
+          'led_duration': 255,
+          'led_effect': 6,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 90,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 0,
+          'led_duration': 255,
+          'led_effect': 6,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+  ])
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_reset][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'led_config_override': None,
+    'notification_on': True,
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'red',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_reset][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open_close',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_reset][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'doors_open',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_reset][service_calls]
+  list([
+  ])
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_reset][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_reset][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.RED: 0>,
+        'duration': None,
+        'effect': <Effect.OPEN_CLOSE: 6>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': 'doors_open',
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-doors_open_on,kitchen_override_leds_reset][zha_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 0,
+          'led_duration': 255,
+          'led_effect': 6,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 90,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 0,
+          'led_duration': 255,
+          'led_effect': 6,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+  ])
+# ---
+# name: test_enable_notification_with_switch_override[zha-kitchen_override,doors_open_on][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'led_config_override': None,
+    'notification_on': True,
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-kitchen_override,doors_open_on][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-kitchen_override,doors_open_on][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'green',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-kitchen_override,doors_open_on][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-kitchen_override,doors_open_on][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'solid',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-kitchen_override,doors_open_on][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'lampie.override',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-kitchen_override,doors_open_on][service_calls]
+  list([
+  ])
+# ---
+# name: test_enable_notification_with_switch_override[zha-kitchen_override,doors_open_on][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-kitchen_override,doors_open_on][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.GREEN: 90>,
+        'duration': None,
+        'effect': <Effect.SOLID: 1>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
+      'value': 'lampie.override',
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_enable_notification_with_switch_override[zha-kitchen_override,doors_open_on][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -1523,7 +2273,168 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_10s_duration_expired][events]
+# name: test_single_config_entry[z2m-doors_open_5m1s_duration_unexpired][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': <ANY>,
+      'expires_at': HAFakeDatetime(2025, 5, 20, 3, 56, 33, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'led_config_override': None,
+    'notification_on': True,
+  })
+# ---
+# name: test_single_config_entry[z2m-doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_single_config_entry[z2m-doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'red',
+  })
+# ---
+# name: test_single_config_entry[z2m-doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '301',
+  })
+# ---
+# name: test_single_config_entry[z2m-doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open_close',
+  })
+# ---
+# name: test_single_config_entry[z2m-doors_open_5m1s_duration_unexpired][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'doors_open',
+  })
+# ---
+# name: test_single_config_entry[z2m-doors_open_5m1s_duration_unexpired][service_calls]
+  list([
+  ])
+# ---
+# name: test_single_config_entry[z2m-doors_open_5m1s_duration_unexpired][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'expires_at': '2025-05-20T03:56:33.003245-07:00',
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+      'started_at': '2025-05-20T03:51:32.003245-07:00',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_single_config_entry[z2m-doors_open_5m1s_duration_unexpired][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.RED: 0>,
+        'duration': 301,
+        'effect': <Effect.OPEN_CLOSE: 6>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': 'doors_open',
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_single_config_entry[z2m-doors_open_5m1s_duration_unexpired][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_single_config_entry[z2m-doors_open_various_firmware_durations_expired][events]
   list([
     EventSnapshot({
       'context': <ANY>,
@@ -1537,7 +2448,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_10s_duration_expired][notification_info]
+# name: test_single_config_entry[z2m-doors_open_various_firmware_durations_expired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -1548,7 +2459,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_single_config_entry[doors_open_10s_duration_expired][sensor.kitchen_effect_brightness]
+# name: test_single_config_entry[z2m-doors_open_various_firmware_durations_expired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -1564,7 +2475,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_10s_duration_expired][sensor.kitchen_effect_color]
+# name: test_single_config_entry[z2m-doors_open_various_firmware_durations_expired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -1578,7 +2489,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_10s_duration_expired][sensor.kitchen_effect_duration]
+# name: test_single_config_entry[z2m-doors_open_various_firmware_durations_expired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -1594,7 +2505,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_10s_duration_expired][sensor.kitchen_effect_type]
+# name: test_single_config_entry[z2m-doors_open_various_firmware_durations_expired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -1608,7 +2519,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_10s_duration_expired][sensor.kitchen_notification]
+# name: test_single_config_entry[z2m-doors_open_various_firmware_durations_expired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -1622,11 +2533,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_10s_duration_expired][service_calls]
+# name: test_single_config_entry[z2m-doors_open_various_firmware_durations_expired][service_calls]
   list([
   ])
 # ---
-# name: test_single_config_entry[doors_open_10s_duration_expired][switch.doors_open_notification]
+# name: test_single_config_entry[z2m-doors_open_various_firmware_durations_expired][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -1640,13 +2551,18 @@
     'state': 'off',
   })
 # ---
-# name: test_single_config_entry[doors_open_10s_duration_expired][switch_info]
+# name: test_single_config_entry[z2m-doors_open_various_firmware_durations_expired][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
     ),
@@ -1654,13 +2570,244 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_10s_duration_expired][zha_cluster_commands]
+# name: test_single_config_entry[z2m-doors_open_various_firmware_durations_expired][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":30,"led_number":0}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":65,"led_number":1}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":122,"led_number":2}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":30,"led_number":3}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":122,"led_number":4}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":65,"led_number":5}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":30,"led_number":6}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_single_config_entry[zha-doors_open_10s_duration_expired][events]
+  list([
+    EventSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'notification': 'doors_open',
+      }),
+      'event_type': 'lampie.expired',
+      'id': <ANY>,
+      'origin': 'LOCAL',
+      'time_fired': <ANY>,
+    }),
+  ])
+# ---
+# name: test_single_config_entry[zha-doors_open_10s_duration_expired][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_10s_duration_expired][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_10s_duration_expired][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_10s_duration_expired][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_10s_duration_expired][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_10s_duration_expired][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_10s_duration_expired][service_calls]
+  list([
+  ])
+# ---
+# name: test_single_config_entry[zha-doors_open_10s_duration_expired][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_10s_duration_expired][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_10s_duration_expired][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -1686,7 +2833,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_dismissed][events]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed][events]
   list([
     EventSnapshot({
       'context': <ANY>,
@@ -1700,7 +2847,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_dismissed][notification_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -1711,7 +2858,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_dismissed][sensor.kitchen_effect_brightness]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -1727,7 +2874,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_dismissed][sensor.kitchen_effect_color]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -1741,7 +2888,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_dismissed][sensor.kitchen_effect_duration]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -1757,7 +2904,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_dismissed][sensor.kitchen_effect_type]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -1771,7 +2918,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_dismissed][sensor.kitchen_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -1785,11 +2932,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_dismissed][service_calls]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed][service_calls]
   list([
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_dismissed][switch.doors_open_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -1803,13 +2950,17 @@
     'state': 'off',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_dismissed][switch_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -1817,13 +2968,12 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_dismissed][zha_cluster_commands]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -1849,21 +2999,21 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired][events]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled][events]
   list([
     EventSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
         'notification': 'doors_open',
       }),
-      'event_type': 'lampie.expired',
+      'event_type': 'lampie.dismissed',
       'id': <ANY>,
       'origin': 'LOCAL',
       'time_fired': <ANY>,
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired][notification_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -1874,7 +3024,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired][sensor.kitchen_effect_brightness]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -1890,7 +3040,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired][sensor.kitchen_effect_color]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -1904,7 +3054,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired][sensor.kitchen_effect_duration]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -1920,7 +3070,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired][sensor.kitchen_effect_type]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -1934,7 +3084,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired][sensor.kitchen_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -1948,11 +3098,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired][service_calls]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled][service_calls]
   list([
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired][switch.doors_open_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -1966,13 +3116,17 @@
     'state': 'off',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired][switch_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -1980,13 +3134,12 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired][zha_cluster_commands]
+# name: test_single_config_entry[zha-doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -2034,7 +3187,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired_not_blocked_via_end_action][events]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired][events]
   list([
     EventSnapshot({
       'context': <ANY>,
@@ -2048,7 +3201,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired_not_blocked_via_end_action][notification_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -2059,7 +3212,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired_not_blocked_via_end_action][sensor.kitchen_effect_brightness]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -2075,7 +3228,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired_not_blocked_via_end_action][sensor.kitchen_effect_color]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -2089,7 +3242,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired_not_blocked_via_end_action][sensor.kitchen_effect_duration]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -2105,7 +3258,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired_not_blocked_via_end_action][sensor.kitchen_effect_type]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -2119,7 +3272,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired_not_blocked_via_end_action][sensor.kitchen_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -2133,7 +3286,195 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired_not_blocked_via_end_action][service_calls]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired][service_calls]
+  list([
+  ])
+# ---
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired][zha_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 0,
+          'led_duration': 255,
+          'led_effect': 6,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 255,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+  ])
+# ---
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired_not_blocked_via_end_action][events]
+  list([
+    EventSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'notification': 'doors_open',
+      }),
+      'event_type': 'lampie.expired',
+      'id': <ANY>,
+      'origin': 'LOCAL',
+      'time_fired': <ANY>,
+    }),
+  ])
+# ---
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired_not_blocked_via_end_action][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired_not_blocked_via_end_action][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired_not_blocked_via_end_action][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired_not_blocked_via_end_action][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired_not_blocked_via_end_action][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired_not_blocked_via_end_action][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired_not_blocked_via_end_action][service_calls]
   list([
     tuple(
       'script',
@@ -2147,7 +3488,7 @@
     ),
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired_not_blocked_via_end_action][switch.doors_open_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired_not_blocked_via_end_action][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -2161,13 +3502,17 @@
     'state': 'off',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired_not_blocked_via_end_action][switch_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired_not_blocked_via_end_action][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -2175,13 +3520,12 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_expired_not_blocked_via_end_action][zha_cluster_commands]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_expired_not_blocked_via_end_action][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -2229,7 +3573,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_unexpired][notification_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_unexpired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': <ANY>,
@@ -2240,7 +3584,7 @@
     'notification_on': True,
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_brightness]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -2256,7 +3600,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_color]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -2270,7 +3614,7 @@
     'state': 'red',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_duration]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -2286,7 +3630,7 @@
     'state': '301',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_type]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_unexpired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -2300,7 +3644,7 @@
     'state': 'open_close',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_unexpired][sensor.kitchen_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_unexpired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -2314,11 +3658,11 @@
     'state': 'doors_open',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_unexpired][service_calls]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_unexpired][service_calls]
   list([
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_unexpired][switch.doors_open_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_unexpired][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'expires_at': '2025-05-20T03:56:33.003245-07:00',
@@ -2334,13 +3678,17 @@
     'state': 'on',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_unexpired][switch_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_unexpired][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
       dict({
@@ -2354,13 +3702,12 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': 'doors_open',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_duration_unexpired][zha_cluster_commands]
+# name: test_single_config_entry[zha-doors_open_5m1s_duration_unexpired][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -2386,7 +3733,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_reactivated_and_unexpired][notification_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_reactivated_and_unexpired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': <ANY>,
@@ -2397,7 +3744,7 @@
     'notification_on': True,
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_reactivated_and_unexpired][sensor.kitchen_effect_brightness]
+# name: test_single_config_entry[zha-doors_open_5m1s_reactivated_and_unexpired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -2413,7 +3760,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_reactivated_and_unexpired][sensor.kitchen_effect_color]
+# name: test_single_config_entry[zha-doors_open_5m1s_reactivated_and_unexpired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -2427,7 +3774,7 @@
     'state': 'red',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_reactivated_and_unexpired][sensor.kitchen_effect_duration]
+# name: test_single_config_entry[zha-doors_open_5m1s_reactivated_and_unexpired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -2443,7 +3790,7 @@
     'state': '301',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_reactivated_and_unexpired][sensor.kitchen_effect_type]
+# name: test_single_config_entry[zha-doors_open_5m1s_reactivated_and_unexpired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -2457,7 +3804,7 @@
     'state': 'open_close',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_reactivated_and_unexpired][sensor.kitchen_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_reactivated_and_unexpired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -2471,11 +3818,11 @@
     'state': 'doors_open',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_reactivated_and_unexpired][service_calls]
+# name: test_single_config_entry[zha-doors_open_5m1s_reactivated_and_unexpired][service_calls]
   list([
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_reactivated_and_unexpired][switch.doors_open_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_reactivated_and_unexpired][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'expires_at': '2025-05-20T03:56:33.003245-07:00',
@@ -2491,13 +3838,17 @@
     'state': 'on',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_reactivated_and_unexpired][switch_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_reactivated_and_unexpired][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
       dict({
@@ -2511,13 +3862,12 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': 'doors_open',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_reactivated_and_unexpired][zha_cluster_commands]
+# name: test_single_config_entry[zha-doors_open_5m1s_reactivated_and_unexpired][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -2543,7 +3893,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_turned_off][notification_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_turned_off][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -2554,7 +3904,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_turned_off][sensor.kitchen_effect_brightness]
+# name: test_single_config_entry[zha-doors_open_5m1s_turned_off][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -2570,7 +3920,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_turned_off][sensor.kitchen_effect_color]
+# name: test_single_config_entry[zha-doors_open_5m1s_turned_off][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -2584,7 +3934,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_turned_off][sensor.kitchen_effect_duration]
+# name: test_single_config_entry[zha-doors_open_5m1s_turned_off][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -2600,7 +3950,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_turned_off][sensor.kitchen_effect_type]
+# name: test_single_config_entry[zha-doors_open_5m1s_turned_off][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -2614,7 +3964,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_turned_off][sensor.kitchen_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_turned_off][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -2628,11 +3978,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_turned_off][service_calls]
+# name: test_single_config_entry[zha-doors_open_5m1s_turned_off][service_calls]
   list([
   ])
 # ---
-# name: test_single_config_entry[doors_open_5m1s_turned_off][switch.doors_open_notification]
+# name: test_single_config_entry[zha-doors_open_5m1s_turned_off][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -2646,13 +3996,17 @@
     'state': 'off',
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_turned_off][switch_info]
+# name: test_single_config_entry[zha-doors_open_5m1s_turned_off][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -2660,13 +4014,12 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_5m1s_turned_off][zha_cluster_commands]
+# name: test_single_config_entry[zha-doors_open_5m1s_turned_off][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -2714,7 +4067,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_expired][events]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_expired][events]
   list([
     EventSnapshot({
       'context': <ANY>,
@@ -2728,7 +4081,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_expired][notification_info]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_expired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -2739,7 +4092,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_expired][sensor.kitchen_effect_brightness]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_expired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -2755,7 +4108,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_expired][sensor.kitchen_effect_color]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_expired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -2769,7 +4122,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_expired][sensor.kitchen_effect_duration]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_expired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -2785,7 +4138,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_expired][sensor.kitchen_effect_type]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_expired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -2799,7 +4152,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_expired][sensor.kitchen_notification]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_expired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -2813,11 +4166,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_expired][service_calls]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_expired][service_calls]
   list([
   ])
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_expired][switch.doors_open_notification]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_expired][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -2831,13 +4184,17 @@
     'state': 'off',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_expired][switch_info]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_expired][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -2845,13 +4202,12 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_expired][zha_cluster_commands]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_expired][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -3177,7 +4533,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_partially_expired][notification_info]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_partially_expired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': <ANY>,
@@ -3188,7 +4544,7 @@
     'notification_on': True,
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_partially_expired][sensor.kitchen_effect_brightness]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_partially_expired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -3213,7 +4569,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_partially_expired][sensor.kitchen_effect_color]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_partially_expired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -3236,7 +4592,7 @@
     'state': 'multi',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_partially_expired][sensor.kitchen_effect_duration]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_partially_expired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -3261,7 +4617,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_partially_expired][sensor.kitchen_effect_type]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_partially_expired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -3284,7 +4640,7 @@
     'state': 'multi',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_partially_expired][sensor.kitchen_notification]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_partially_expired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -3298,11 +4654,11 @@
     'state': 'doors_open',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_partially_expired][service_calls]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_partially_expired][service_calls]
   list([
   ])
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_partially_expired][switch.doors_open_notification]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_partially_expired][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'expires_at': '2025-05-20T04:01:33.003245-07:00',
@@ -3318,13 +4674,17 @@
     'state': 'on',
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_partially_expired][switch_info]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_partially_expired][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
       dict({
@@ -3374,13 +4734,12 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': 'doors_open',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_mixed_specific_durations_partially_expired][zha_cluster_commands]
+# name: test_single_config_entry[zha-doors_open_mixed_specific_durations_partially_expired][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -3591,7 +4950,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][events]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][events]
   list([
     EventSnapshot({
       'context': <ANY>,
@@ -3605,7 +4964,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][notification_info]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -3616,7 +4975,81 @@
     'notification_on': False,
   })
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][sensor.kitchen_effect_brightness]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][sensor.entryway_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Entryway Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.entryway_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][sensor.entryway_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Entryway Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.entryway_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][sensor.entryway_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Entryway Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.entryway_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][sensor.entryway_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Entryway Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.entryway_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][sensor.entryway_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Entryway Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.entryway_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -3632,7 +5065,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][sensor.kitchen_effect_color]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -3646,7 +5079,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][sensor.kitchen_effect_duration]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -3662,7 +5095,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][sensor.kitchen_effect_type]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -3676,7 +5109,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][sensor.kitchen_notification]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -3690,11 +5123,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][service_calls]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][service_calls]
   list([
   ])
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][switch.doors_open_notification]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -3708,13 +5141,17 @@
     'state': 'off',
   })
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][switch_info:light.entryway]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][switch_info:light.entryway]
   dict({
-    'disable_clear_notification_id': None,
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.entryway_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.entryway_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -3722,19 +5159,22 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': None,
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][switch_info]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -3742,13 +5182,12 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_multiple_switches_dismissed][zha_cluster_commands]
+# name: test_single_config_entry[zha-doors_open_multiple_switches_dismissed][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -3818,7 +5257,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_various_firmware_durations_expired][events]
+# name: test_single_config_entry[zha-doors_open_various_firmware_durations_expired][events]
   list([
     EventSnapshot({
       'context': <ANY>,
@@ -3832,7 +5271,7 @@
     }),
   ])
 # ---
-# name: test_single_config_entry[doors_open_various_firmware_durations_expired][notification_info]
+# name: test_single_config_entry[zha-doors_open_various_firmware_durations_expired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -3843,7 +5282,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_single_config_entry[doors_open_various_firmware_durations_expired][sensor.kitchen_effect_brightness]
+# name: test_single_config_entry[zha-doors_open_various_firmware_durations_expired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -3859,7 +5298,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_various_firmware_durations_expired][sensor.kitchen_effect_color]
+# name: test_single_config_entry[zha-doors_open_various_firmware_durations_expired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -3873,7 +5312,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_various_firmware_durations_expired][sensor.kitchen_effect_duration]
+# name: test_single_config_entry[zha-doors_open_various_firmware_durations_expired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -3889,7 +5328,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_various_firmware_durations_expired][sensor.kitchen_effect_type]
+# name: test_single_config_entry[zha-doors_open_various_firmware_durations_expired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -3903,7 +5342,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_various_firmware_durations_expired][sensor.kitchen_notification]
+# name: test_single_config_entry[zha-doors_open_various_firmware_durations_expired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -3917,11 +5356,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_single_config_entry[doors_open_various_firmware_durations_expired][service_calls]
+# name: test_single_config_entry[zha-doors_open_various_firmware_durations_expired][service_calls]
   list([
   ])
 # ---
-# name: test_single_config_entry[doors_open_various_firmware_durations_expired][switch.doors_open_notification]
+# name: test_single_config_entry[zha-doors_open_various_firmware_durations_expired][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -3935,13 +5374,17 @@
     'state': 'off',
   })
 # ---
-# name: test_single_config_entry[doors_open_various_firmware_durations_expired][switch_info]
+# name: test_single_config_entry[zha-doors_open_various_firmware_durations_expired][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -3949,13 +5392,12 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_single_config_entry[doors_open_various_firmware_durations_expired][zha_cluster_commands]
+# name: test_single_config_entry[zha-doors_open_various_firmware_durations_expired][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -4120,7 +5562,7 @@
     }),
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_dismissed][events]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_dismissed][events]
   list([
     EventSnapshot({
       'context': <ANY>,
@@ -4135,7 +5577,7 @@
     }),
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_dismissed][notification_info]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_dismissed][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -4146,7 +5588,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_brightness]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -4162,7 +5604,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_color]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -4176,7 +5618,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_duration]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -4192,7 +5634,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_type]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -4206,7 +5648,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_notification]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -4220,11 +5662,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_dismissed][service_calls]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_dismissed][service_calls]
   list([
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_dismissed][switch.doors_open_notification]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_dismissed][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -4238,13 +5680,18 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_dismissed][switch_info]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_dismissed][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
     ),
@@ -4252,39 +5699,38 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_dismissed][zha_cluster_commands]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_dismissed][z2m_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 90,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-        }),
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
     }),
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_unexpired][notification_info]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_unexpired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -4295,7 +5741,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_brightness]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -4311,7 +5757,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_color]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -4325,7 +5771,7 @@
     'state': 'green',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_duration]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'expires_at': '2025-05-20T03:56:33.003245-07:00',
@@ -4343,7 +5789,7 @@
     'state': '301.0',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_type]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -4357,7 +5803,7 @@
     'state': 'solid',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_notification]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -4371,11 +5817,11 @@
     'state': 'lampie.override',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_unexpired][service_calls]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_unexpired][service_calls]
   list([
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_unexpired][switch.doors_open_notification]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_unexpired][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -4389,13 +5835,18 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_unexpired][switch_info]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_unexpired][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': <ANY>,
       'expires_at': HAFakeDatetime(2025, 5, 20, 3, 56, 33, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
       dict({
@@ -4409,39 +5860,38 @@
       'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'lampie.override',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_5m1s_duration_unexpired][zha_cluster_commands]
+# name: test_switch_override[z2m-kitchen_override_leds_5m1s_duration_unexpired][z2m_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 90,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-        }),
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
     }),
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_clear][notification_info]
+# name: test_switch_override[z2m-kitchen_override_leds_clear][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -4452,7 +5902,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_clear][sensor.kitchen_effect_brightness]
+# name: test_switch_override[z2m-kitchen_override_leds_clear][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -4468,7 +5918,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_clear][sensor.kitchen_effect_color]
+# name: test_switch_override[z2m-kitchen_override_leds_clear][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -4482,7 +5932,7 @@
     'state': 'blue',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_clear][sensor.kitchen_effect_duration]
+# name: test_switch_override[z2m-kitchen_override_leds_clear][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -4498,7 +5948,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_clear][sensor.kitchen_effect_type]
+# name: test_switch_override[z2m-kitchen_override_leds_clear][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -4512,7 +5962,7 @@
     'state': 'clear',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_clear][sensor.kitchen_notification]
+# name: test_switch_override[z2m-kitchen_override_leds_clear][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -4526,11 +5976,11 @@
     'state': 'lampie.override',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_clear][service_calls]
+# name: test_switch_override[z2m-kitchen_override_leds_clear][service_calls]
   list([
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_clear][switch.doors_open_notification]
+# name: test_switch_override[z2m-kitchen_override_leds_clear][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -4544,13 +5994,18 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_clear][switch_info]
+# name: test_switch_override[z2m-kitchen_override_leds_clear][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
       dict({
@@ -4564,61 +6019,49 @@
       'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'lampie.override',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_clear][zha_cluster_commands]
+# name: test_switch_override[z2m-kitchen_override_leds_clear][z2m_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 90,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-        }),
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
     }),
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 170,
-          'led_duration': 255,
-          'led_effect': 255,
-          'led_level': 100,
-        }),
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
     }),
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_dismissed][events]
+# name: test_switch_override[z2m-kitchen_override_leds_dismissed][events]
   list([
     EventSnapshot({
       'context': <ANY>,
@@ -4633,7 +6076,7 @@
     }),
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_dismissed][notification_info]
+# name: test_switch_override[z2m-kitchen_override_leds_dismissed][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -4644,7 +6087,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_dismissed][sensor.kitchen_effect_brightness]
+# name: test_switch_override[z2m-kitchen_override_leds_dismissed][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -4660,7 +6103,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_dismissed][sensor.kitchen_effect_color]
+# name: test_switch_override[z2m-kitchen_override_leds_dismissed][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -4674,7 +6117,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_dismissed][sensor.kitchen_effect_duration]
+# name: test_switch_override[z2m-kitchen_override_leds_dismissed][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -4690,7 +6133,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_dismissed][sensor.kitchen_effect_type]
+# name: test_switch_override[z2m-kitchen_override_leds_dismissed][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -4704,7 +6147,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_dismissed][sensor.kitchen_notification]
+# name: test_switch_override[z2m-kitchen_override_leds_dismissed][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -4718,11 +6161,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_dismissed][service_calls]
+# name: test_switch_override[z2m-kitchen_override_leds_dismissed][service_calls]
   list([
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_dismissed][switch.doors_open_notification]
+# name: test_switch_override[z2m-kitchen_override_leds_dismissed][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -4736,13 +6179,18 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_dismissed][switch_info]
+# name: test_switch_override[z2m-kitchen_override_leds_dismissed][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
     ),
@@ -4750,39 +6198,38 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_dismissed][zha_cluster_commands]
+# name: test_switch_override[z2m-kitchen_override_leds_dismissed][z2m_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 90,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-        }),
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
       }),
-      'domain': 'zha',
+      'domain': 'mqtt',
       'hass': <ANY>,
       'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
     }),
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_named][notification_info]
+# name: test_switch_override[z2m-kitchen_override_leds_named][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -4793,7 +6240,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_named][sensor.kitchen_effect_brightness]
+# name: test_switch_override[z2m-kitchen_override_leds_named][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -4809,7 +6256,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_named][sensor.kitchen_effect_color]
+# name: test_switch_override[z2m-kitchen_override_leds_named][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -4823,7 +6270,7 @@
     'state': 'green',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_named][sensor.kitchen_effect_duration]
+# name: test_switch_override[z2m-kitchen_override_leds_named][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -4839,7 +6286,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_named][sensor.kitchen_effect_type]
+# name: test_switch_override[z2m-kitchen_override_leds_named][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -4853,7 +6300,7 @@
     'state': 'solid',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_named][sensor.kitchen_notification]
+# name: test_switch_override[z2m-kitchen_override_leds_named][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -4867,11 +6314,11 @@
     'state': 'customized_name',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_named][service_calls]
+# name: test_switch_override[z2m-kitchen_override_leds_named][service_calls]
   list([
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_named][switch.doors_open_notification]
+# name: test_switch_override[z2m-kitchen_override_leds_named][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -4885,13 +6332,18 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_named][switch_info]
+# name: test_switch_override[z2m-kitchen_override_leds_named][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
       dict({
@@ -4905,13 +6357,343 @@
       'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'customized_name',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_named][zha_cluster_commands]
+# name: test_switch_override[z2m-kitchen_override_leds_named][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_switch_override[z2m-kitchen_override_leds_reset][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override[z2m-kitchen_override_leds_reset][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[z2m-kitchen_override_leds_reset][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[z2m-kitchen_override_leds_reset][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[z2m-kitchen_override_leds_reset][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[z2m-kitchen_override_leds_reset][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[z2m-kitchen_override_leds_reset][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override[z2m-kitchen_override_leds_reset][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override[z2m-kitchen_override_leds_reset][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override[z2m-kitchen_override_leds_reset][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_dismissed][events]
+  list([
+    EventSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'entity_id': 'light.kitchen',
+        'override': 'lampie.override',
+      }),
+      'event_type': 'lampie.dismissed',
+      'id': <ANY>,
+      'origin': 'LOCAL',
+      'time_fired': <ANY>,
+    }),
+  ])
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_dismissed][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_dismissed][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_dismissed][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_dismissed][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_dismissed][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_dismissed][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -4937,7 +6719,7 @@
     }),
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_reset][notification_info]
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_unexpired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -4948,7 +6730,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_reset][sensor.kitchen_effect_brightness]
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -4961,10 +6743,10 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '100.0',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_reset][sensor.kitchen_effect_color]
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -4975,10 +6757,170 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'green',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_reset][sensor.kitchen_effect_duration]
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'expires_at': '2025-05-20T03:56:33.003245-07:00',
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'started_at': '2025-05-20T03:51:32.003245-07:00',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '301.0',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'solid',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_unexpired][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'lampie.override',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_unexpired][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_unexpired][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_unexpired][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': <ANY>,
+      'expires_at': HAFakeDatetime(2025, 5, 20, 3, 56, 33, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.GREEN: 90>,
+        'duration': 301.0,
+        'effect': <Effect.SOLID: 1>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
+      'value': 'lampie.override',
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_5m1s_duration_unexpired][zha_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 90,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+  ])
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_clear][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_clear][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_clear][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'blue',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_clear][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -4994,7 +6936,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_reset][sensor.kitchen_effect_type]
+# name: test_switch_override[zha-kitchen_override_leds_clear][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -5005,10 +6947,10 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'clear',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_reset][sensor.kitchen_notification]
+# name: test_switch_override[zha-kitchen_override_leds_clear][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -5019,14 +6961,14 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'lampie.override',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_reset][service_calls]
+# name: test_switch_override[zha-kitchen_override_leds_clear][service_calls]
   list([
   ])
 # ---
-# name: test_switch_override[kitchen_override_leds_reset][switch.doors_open_notification]
+# name: test_switch_override[zha-kitchen_override_leds_clear][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -5040,27 +6982,36 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_reset][switch_info]
+# name: test_switch_override[zha-kitchen_override_leds_clear][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
     }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
     'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.BLUE: 170>,
+        'duration': None,
+        'effect': <Effect.CLEAR: 255>,
+      }),
     ),
     'led_config_source': dict({
-      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
-      'value': None,
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
+      'value': 'lampie.override',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_switch_override[kitchen_override_leds_reset][zha_cluster_commands]
+# name: test_switch_override[zha-kitchen_override_leds_clear][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -5108,267 +7059,135 @@
     }),
   ])
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_no_override_dismissed][notification_info]
-  dict({
-    'expiration': ExpirationInfoSnapshot({
-      'cancel_listener': None,
-      'expires_at': None,
-      'started_at': None,
-    }),
-    'led_config_override': None,
-    'notification_on': False,
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_no_override_dismissed][sensor.kitchen_effect_brightness]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Effect brightness',
-      'icon': 'mdi:brightness-percent',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kitchen_effect_brightness',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_no_override_dismissed][sensor.kitchen_effect_color]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Effect color',
-      'icon': 'mdi:palette',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kitchen_effect_color',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_no_override_dismissed][sensor.kitchen_effect_duration]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Effect duration',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kitchen_effect_duration',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_no_override_dismissed][sensor.kitchen_effect_type]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Effect type',
-      'icon': 'mdi:star-four-points-box',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kitchen_effect_type',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_no_override_dismissed][sensor.kitchen_notification]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Notification',
-      'icon': 'mdi:circle-box',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kitchen_notification',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_no_override_dismissed][service_calls]
+# name: test_switch_override[zha-kitchen_override_leds_dismissed][events]
   list([
-  ])
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_no_override_dismissed][switch.doors_open_notification]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Doors Open Notification',
-      'icon': 'mdi:circle-box',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.doors_open_notification',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_no_override_dismissed][switch_info:light.entryway]
-  None
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_no_override_dismissed][switch_info]
-  dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
-    'expiration': ExpirationInfoSnapshot({
-      'cancel_listener': None,
-      'expires_at': None,
-      'started_at': None,
-    }),
-    'led_config': tuple(
-    ),
-    'led_config_source': dict({
-      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
-      'value': None,
-    }),
-    'local_protection_id': 'switch.kitchen_local_protection',
-    'priorities': tuple(
-      'doors_open',
-    ),
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_override][notification_info]
-  dict({
-    'expiration': ExpirationInfoSnapshot({
-      'cancel_listener': None,
-      'expires_at': None,
-      'started_at': None,
-    }),
-    'led_config_override': None,
-    'notification_on': False,
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_override][sensor.kitchen_effect_brightness]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Effect brightness',
-      'icon': 'mdi:brightness-percent',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kitchen_effect_brightness',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_override][sensor.kitchen_effect_color]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Effect color',
-      'icon': 'mdi:palette',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kitchen_effect_color',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_override][sensor.kitchen_effect_duration]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Effect duration',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kitchen_effect_duration',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_override][sensor.kitchen_effect_type]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Effect type',
-      'icon': 'mdi:star-four-points-box',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kitchen_effect_type',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_override][sensor.kitchen_notification]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kitchen Notification',
-      'icon': 'mdi:circle-box',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kitchen_notification',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_override][service_calls]
-  list([
-  ])
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_override][switch.doors_open_notification]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Doors Open Notification',
-      'icon': 'mdi:circle-box',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.doors_open_notification',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_switch_override_on_unrelated_switch[entryway_override][switch_info:light.entryway]
-  dict({
-    'disable_clear_notification_id': 'switch.entryway_disable_config_2x_tap_to_clear_notifications',
-    'expiration': ExpirationInfoSnapshot({
-      'cancel_listener': None,
-      'expires_at': None,
-      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
-    }),
-    'led_config': tuple(
-      dict({
-        'brightness': 100.0,
-        'color': <Color.GREEN: 90>,
-        'duration': None,
-        'effect': <Effect.SOLID: 1>,
+    EventSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'entity_id': 'light.kitchen',
+        'override': 'lampie.override',
       }),
-    ),
-    'led_config_source': dict({
-      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
-      'value': 'lampie.override',
+      'event_type': 'lampie.dismissed',
+      'id': <ANY>,
+      'origin': 'LOCAL',
+      'time_fired': <ANY>,
     }),
-    'local_protection_id': 'switch.entryway_local_protection',
-    'priorities': tuple(
-    ),
-  })
+  ])
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override][switch_info]
+# name: test_switch_override[zha-kitchen_override_leds_dismissed][notification_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_dismissed][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_dismissed][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_dismissed][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_dismissed][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_dismissed][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_dismissed][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_dismissed][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_dismissed][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -5376,13 +7195,12 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override][zha_cluster_commands]
+# name: test_switch_override[zha-kitchen_override_leds_dismissed][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -5392,7 +7210,7 @@
         'command': 1,
         'command_type': 'server',
         'endpoint_id': 1,
-        'ieee': 'mock-ieee:entryway',
+        'ieee': 'mock-ieee:kitchen',
         'manufacturer': 4655,
         'params': dict({
           'led_color': 90,
@@ -5408,7 +7226,677 @@
     }),
   ])
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][events]
+# name: test_switch_override[zha-kitchen_override_leds_named][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_named][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_named][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'green',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_named][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_named][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'solid',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_named][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'customized_name',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_named][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_named][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_named][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.GREEN: 90>,
+        'duration': None,
+        'effect': <Effect.SOLID: 1>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
+      'value': 'customized_name',
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_named][zha_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 90,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+  ])
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_reset][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_reset][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_reset][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_reset][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_reset][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_reset][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_reset][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_reset][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_reset][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override[zha-kitchen_override_leds_reset][zha_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 90,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 255,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+  ])
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_no_override_dismissed][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_no_override_dismissed][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_no_override_dismissed][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_no_override_dismissed][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_no_override_dismissed][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_no_override_dismissed][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_no_override_dismissed][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_no_override_dismissed][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_no_override_dismissed][switch_info:light.entryway]
+  None
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_no_override_dismissed][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_no_override_dismissed][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override][switch_info:light.entryway]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Entryway',
+      'local_protection_enabled': None,
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.GREEN: 90>,
+        'duration': None,
+        'effect': <Effect.SOLID: 1>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
+      'value': 'lampie.override',
+    }),
+    'priorities': tuple(
+    ),
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Entryway/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Entryway/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][events]
   list([
     EventSnapshot({
       'context': <ANY>,
@@ -5423,7 +7911,7 @@
     }),
   ])
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][notification_info]
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -5434,7 +7922,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][sensor.kitchen_effect_brightness]
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -5450,7 +7938,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][sensor.kitchen_effect_color]
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -5464,7 +7952,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][sensor.kitchen_effect_duration]
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -5480,7 +7968,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][sensor.kitchen_effect_type]
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -5494,7 +7982,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][sensor.kitchen_notification]
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -5508,11 +7996,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][service_calls]
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][service_calls]
   list([
   ])
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][switch.doors_open_notification]
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -5526,13 +8014,18 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][switch_info:light.entryway]
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][switch_info:light.entryway]
   dict({
-    'disable_clear_notification_id': 'switch.entryway_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Entryway',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
     ),
@@ -5540,18 +8033,22 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.entryway_local_protection',
     'priorities': tuple(
     ),
   })
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][switch_info]
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
     ),
@@ -5559,13 +8056,525 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_switch_override_on_unrelated_switch[entryway_override_expired][zha_cluster_commands]
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_expired][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Entryway/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Entryway/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_unrelated_command][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_unrelated_command][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_unrelated_command][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_unrelated_command][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_unrelated_command][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_unrelated_command][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_unrelated_command][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_unrelated_command][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_unrelated_command][switch_info:light.entryway]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Entryway',
+      'local_protection_enabled': None,
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.GREEN: 90>,
+        'duration': None,
+        'effect': <Effect.SOLID: 1>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
+      'value': 'lampie.override',
+    }),
+    'priorities': tuple(
+    ),
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_unrelated_command][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[z2m-entryway_override_unrelated_command][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Entryway/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Entryway/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_no_override_dismissed][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_no_override_dismissed][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_no_override_dismissed][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_no_override_dismissed][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_no_override_dismissed][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_no_override_dismissed][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_no_override_dismissed][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_no_override_dismissed][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_no_override_dismissed][switch_info:light.entryway]
+  None
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_no_override_dismissed][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override][switch_info:light.entryway]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.entryway_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.entryway_local_protection',
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.GREEN: 90>,
+        'duration': None,
+        'effect': <Effect.SOLID: 1>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
+      'value': 'lampie.override',
+    }),
+    'priorities': tuple(
+    ),
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -5591,12 +8600,12 @@
     }),
   ])
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_5m1s_duration_expired][events]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][events]
   list([
     EventSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'entity_id': 'light.kitchen',
+        'entity_id': 'light.entryway',
         'override': 'lampie.override',
       }),
       'event_type': 'lampie.expired',
@@ -5606,7 +8615,7 @@
     }),
   ])
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_5m1s_duration_expired][notification_info]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -5617,7 +8626,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_brightness]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -5633,7 +8642,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_color]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -5647,7 +8656,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_duration]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -5663,7 +8672,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_type]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -5677,7 +8686,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_notification]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -5691,11 +8700,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_5m1s_duration_expired][service_calls]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][service_calls]
   list([
   ])
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_5m1s_duration_expired][switch.doors_open_notification]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -5709,13 +8718,17 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_5m1s_duration_expired][switch_info]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][switch_info:light.entryway]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.entryway_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.entryway_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -5723,13 +8736,34 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
+    'priorities': tuple(
+    ),
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_5m1s_duration_expired][zha_cluster_commands]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_expired][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
@@ -5739,7 +8773,7 @@
         'command': 1,
         'command_type': 'server',
         'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
+        'ieee': 'mock-ieee:entryway',
         'manufacturer': 4655,
         'params': dict({
           'led_color': 90,
@@ -5753,46 +8787,9 @@
       'return_response': False,
       'service': 'issue_zigbee_cluster_command',
     }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 1,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 170,
-          'led_duration': 255,
-          'led_effect': 255,
-          'led_level': 100,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
   ])
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_expired][events]
-  list([
-    EventSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'entity_id': 'light.kitchen',
-        'override': 'lampie.override',
-      }),
-      'event_type': 'lampie.expired',
-      'id': <ANY>,
-      'origin': 'LOCAL',
-      'time_fired': <ANY>,
-    }),
-  ])
-# ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_expired][notification_info]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_unrelated_command][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -5803,7 +8800,7 @@
     'notification_on': False,
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_brightness]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_unrelated_command][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -5819,7 +8816,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_color]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_unrelated_command][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -5833,7 +8830,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_duration]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_unrelated_command][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect duration',
@@ -5849,7 +8846,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_type]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_unrelated_command][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -5863,7 +8860,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_notification]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_unrelated_command][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -5877,11 +8874,11 @@
     'state': 'unknown',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_expired][service_calls]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_unrelated_command][service_calls]
   list([
   ])
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_expired][switch.doors_open_notification]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_unrelated_command][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -5895,13 +8892,45 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_expired][switch_info]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_unrelated_command][switch_info:light.entryway]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.entryway_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.entryway_local_protection',
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.GREEN: 90>,
+        'duration': None,
+        'effect': <Effect.SOLID: 1>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
+      'value': 'lampie.override',
+    }),
+    'priorities': tuple(
+    ),
+  })
+# ---
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_unrelated_command][switch_info]
+  dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -5909,329 +8938,28 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_expired][zha_cluster_commands]
+# name: test_switch_override_on_unrelated_switch[zha-entryway_override_unrelated_command][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
         'cluster_id': 64561,
         'cluster_type': 'in',
-        'command': 3,
+        'command': 1,
         'command_type': 'server',
         'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
+        'ieee': 'mock-ieee:entryway',
         'manufacturer': 4655,
         'params': dict({
-          'led_color': 0,
+          'led_color': 90,
           'led_duration': 255,
           'led_effect': 1,
           'led_level': 100,
-          'led_number': 0,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 25,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-          'led_number': 1,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 255,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-          'led_number': 2,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 0,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-          'led_number': 3,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 25,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-          'led_number': 4,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 255,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-          'led_number': 5,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 0,
-          'led_duration': 255,
-          'led_effect': 1,
-          'led_level': 100,
-          'led_number': 6,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 170,
-          'led_duration': 255,
-          'led_effect': 255,
-          'led_level': 100,
-          'led_number': 0,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 170,
-          'led_duration': 255,
-          'led_effect': 255,
-          'led_level': 100,
-          'led_number': 1,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 170,
-          'led_duration': 255,
-          'led_effect': 255,
-          'led_level': 100,
-          'led_number': 3,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 170,
-          'led_duration': 255,
-          'led_effect': 255,
-          'led_level': 100,
-          'led_number': 4,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 170,
-          'led_duration': 255,
-          'led_effect': 255,
-          'led_level': 100,
-          'led_number': 6,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 170,
-          'led_duration': 255,
-          'led_effect': 255,
-          'led_level': 100,
-          'led_number': 2,
-        }),
-      }),
-      'domain': 'zha',
-      'hass': <ANY>,
-      'return_response': False,
-      'service': 'issue_zigbee_cluster_command',
-    }),
-    ServiceCallSnapshot({
-      'context': <ANY>,
-      'data': ReadOnlyDict({
-        'cluster_id': 64561,
-        'cluster_type': 'in',
-        'command': 3,
-        'command_type': 'server',
-        'endpoint_id': 1,
-        'ieee': 'mock-ieee:kitchen',
-        'manufacturer': 4655,
-        'params': dict({
-          'led_color': 170,
-          'led_duration': 255,
-          'led_effect': 255,
-          'led_level': 100,
-          'led_number': 5,
         }),
       }),
       'domain': 'zha',
@@ -6241,7 +8969,22 @@
     }),
   ])
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_partially_expired][notification_info]
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_5m1s_duration_expired][events]
+  list([
+    EventSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'entity_id': 'light.kitchen',
+        'override': 'lampie.override',
+      }),
+      'event_type': 'lampie.expired',
+      'id': <ANY>,
+      'origin': 'LOCAL',
+      'time_fired': <ANY>,
+    }),
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_5m1s_duration_expired][notification_info]
   dict({
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
@@ -6252,7 +8995,482 @@
     'notification_on': False,
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_brightness]
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_5m1s_duration_expired][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_5m1s_duration_expired][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_5m1s_duration_expired][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_5m1s_duration_expired][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_expired][events]
+  list([
+    EventSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'entity_id': 'light.kitchen',
+        'override': 'lampie.override',
+      }),
+      'event_type': 'lampie.expired',
+      'id': <ANY>,
+      'origin': 'LOCAL',
+      'time_fired': <ANY>,
+    }),
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_expired][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_expired][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_expired][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_expired][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_expired][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":0}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":25,"led_effect":1,"led_level":100,"led_duration":255,"led_number":1}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":255,"led_effect":1,"led_level":100,"led_duration":255,"led_number":2}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":3}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":25,"led_effect":1,"led_level":100,"led_duration":255,"led_number":4}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":255,"led_effect":1,"led_level":100,"led_duration":255,"led_number":5}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":6}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":0}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":1}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":3}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":4}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":6}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":2}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":5}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_partially_expired][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_brightness]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect brightness',
@@ -6277,7 +9495,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_color]
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_color]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect color',
@@ -6300,7 +9518,7 @@
     'state': 'multi',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_duration]
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_duration]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'expires_at': '2025-05-20T04:01:33.003245-07:00',
@@ -6327,7 +9545,7 @@
     'state': '601.0',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_type]
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_type]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Effect type',
@@ -6350,7 +9568,7 @@
     'state': 'multi',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_notification]
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Notification',
@@ -6364,11 +9582,11 @@
     'state': 'lampie.override',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_partially_expired][service_calls]
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_partially_expired][service_calls]
   list([
   ])
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_partially_expired][switch.doors_open_notification]
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_partially_expired][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Doors Open Notification',
@@ -6382,13 +9600,18 @@
     'state': 'off',
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_partially_expired][switch_info]
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_partially_expired][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': <ANY>,
       'expires_at': HAFakeDatetime(2025, 5, 20, 4, 1, 33, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.Z2M: 'z2m'>,
+    'integration_info': dict({
+      'double_tap_clear_notifications_disabled': None,
+      'full_topic': 'home/z2m/Kitchen',
+      'local_protection_enabled': None,
     }),
     'led_config': tuple(
       dict({
@@ -6438,13 +9661,988 @@
       'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'lampie.override',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
   })
 # ---
-# name: test_switch_override_with_duration_expired[kitchen_override_leds_mixed_specific_durations_partially_expired][zha_cluster_commands]
+# name: test_switch_override_with_duration_expired[z2m-kitchen_override_leds_mixed_specific_durations_partially_expired][z2m_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"localProtection":"","doubleTapClearNotifications":""}',
+        'topic': 'home/z2m/Kitchen/get',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":0}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":25,"led_effect":1,"led_level":100,"led_duration":255,"led_number":1}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":255,"led_effect":1,"led_level":100,"led_duration":255,"led_number":2}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":3}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":25,"led_effect":1,"led_level":100,"led_duration":255,"led_number":4}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":255,"led_effect":1,"led_level":100,"led_duration":255,"led_number":5}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":6}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":1}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":4}}',
+        'topic': 'home/z2m/Kitchen/set',
+      }),
+      'domain': 'mqtt',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'publish',
+    }),
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_5m1s_duration_expired][events]
+  list([
+    EventSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'entity_id': 'light.kitchen',
+        'override': 'lampie.override',
+      }),
+      'event_type': 'lampie.expired',
+      'id': <ANY>,
+      'origin': 'LOCAL',
+      'time_fired': <ANY>,
+    }),
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_5m1s_duration_expired][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_5m1s_duration_expired][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_5m1s_duration_expired][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_5m1s_duration_expired][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_5m1s_duration_expired][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_5m1s_duration_expired][zha_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 90,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 1,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 255,
+          'led_level': 100,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_expired][events]
+  list([
+    EventSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'entity_id': 'light.kitchen',
+        'override': 'lampie.override',
+      }),
+      'event_type': 'lampie.expired',
+      'id': <ANY>,
+      'origin': 'LOCAL',
+      'time_fired': <ANY>,
+    }),
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_expired][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_expired][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_expired][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_expired][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_expired][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
+      'value': None,
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_expired][zha_cluster_commands]
+  list([
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 0,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+          'led_number': 0,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 25,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+          'led_number': 1,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 255,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+          'led_number': 2,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 0,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+          'led_number': 3,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 25,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+          'led_number': 4,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 255,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+          'led_number': 5,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 0,
+          'led_duration': 255,
+          'led_effect': 1,
+          'led_level': 100,
+          'led_number': 6,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 255,
+          'led_level': 100,
+          'led_number': 0,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 255,
+          'led_level': 100,
+          'led_number': 1,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 255,
+          'led_level': 100,
+          'led_number': 3,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 255,
+          'led_level': 100,
+          'led_number': 4,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 255,
+          'led_level': 100,
+          'led_number': 6,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 255,
+          'led_level': 100,
+          'led_number': 2,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+    ServiceCallSnapshot({
+      'context': <ANY>,
+      'data': ReadOnlyDict({
+        'cluster_id': 64561,
+        'cluster_type': 'in',
+        'command': 3,
+        'command_type': 'server',
+        'endpoint_id': 1,
+        'ieee': 'mock-ieee:kitchen',
+        'manufacturer': 4655,
+        'params': dict({
+          'led_color': 170,
+          'led_duration': 255,
+          'led_effect': 255,
+          'led_level': 100,
+          'led_number': 5,
+        }),
+      }),
+      'domain': 'zha',
+      'hass': <ANY>,
+      'return_response': False,
+      'service': 'issue_zigbee_cluster_command',
+    }),
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_partially_expired][notification_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': None,
+      'expires_at': None,
+      'started_at': None,
+    }),
+    'led_config_override': None,
+    'notification_on': False,
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'individual': list([
+        100.0,
+        100.0,
+        100.0,
+        100.0,
+        100.0,
+        100.0,
+        100.0,
+      ]),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+      'individual': list([
+        'red',
+        'blue',
+        'white',
+        'red',
+        'blue',
+        'white',
+        0,
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'multi',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'expires_at': '2025-05-20T04:01:33.003245-07:00',
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'individual': list([
+        601.0,
+        0,
+        601.0,
+        601.0,
+        0,
+        601.0,
+        601.0,
+      ]),
+      'started_at': '2025-05-20T03:51:32.003245-07:00',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '601.0',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+      'individual': list([
+        'solid',
+        'clear',
+        'solid',
+        'solid',
+        'clear',
+        'solid',
+        'solid',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'multi',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_partially_expired][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'lampie.override',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_partially_expired][service_calls]
+  list([
+  ])
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_partially_expired][switch.doors_open_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Doors Open Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.doors_open_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_partially_expired][switch_info]
+  dict({
+    'expiration': ExpirationInfoSnapshot({
+      'cancel_listener': <ANY>,
+      'expires_at': HAFakeDatetime(2025, 5, 20, 4, 1, 33, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'started_at': HAFakeDatetime(2025, 5, 20, 3, 51, 32, 3245, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
+    }),
+    'led_config': tuple(
+      dict({
+        'brightness': 100.0,
+        'color': <Color.RED: 0>,
+        'duration': 601.0,
+        'effect': <Effect.SOLID: 1>,
+      }),
+      dict({
+        'brightness': 100.0,
+        'color': <Color.BLUE: 170>,
+        'duration': 0,
+        'effect': <Effect.CLEAR: 255>,
+      }),
+      dict({
+        'brightness': 100.0,
+        'color': <Color.WHITE: 255>,
+        'duration': 601.0,
+        'effect': <Effect.SOLID: 1>,
+      }),
+      dict({
+        'brightness': 100.0,
+        'color': <Color.RED: 0>,
+        'duration': 601.0,
+        'effect': <Effect.SOLID: 1>,
+      }),
+      dict({
+        'brightness': 100.0,
+        'color': <Color.BLUE: 170>,
+        'duration': 0,
+        'effect': <Effect.CLEAR: 255>,
+      }),
+      dict({
+        'brightness': 100.0,
+        'color': <Color.WHITE: 255>,
+        'duration': 601.0,
+        'effect': <Effect.SOLID: 1>,
+      }),
+      dict({
+        'brightness': 100.0,
+        'color': 0,
+        'duration': 601.0,
+        'effect': <Effect.SOLID: 1>,
+      }),
+    ),
+    'led_config_source': dict({
+      'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
+      'value': 'lampie.override',
+    }),
+    'priorities': tuple(
+      'doors_open',
+    ),
+  })
+# ---
+# name: test_switch_override_with_duration_expired[zha-kitchen_override_leds_mixed_specific_durations_partially_expired][zha_cluster_commands]
   list([
     ServiceCallSnapshot({
       'context': <ANY>,

--- a/tests/snapshots/test_scenarios.ambr
+++ b/tests/snapshots/test_scenarios.ambr
@@ -911,7 +911,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -922,7 +922,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -933,7 +933,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1107,7 +1107,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1118,7 +1118,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1129,7 +1129,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1288,7 +1288,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1299,7 +1299,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1310,7 +1310,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1469,7 +1469,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2424,7 +2424,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":0,"led_effect":6,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2591,7 +2591,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":30,"led_number":0}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":30,"led":0}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2602,7 +2602,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":65,"led_number":1}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":65,"led":1}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2613,7 +2613,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":122,"led_number":2}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":122,"led":2}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2624,7 +2624,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":30,"led_number":3}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":30,"led":3}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2635,7 +2635,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":122,"led_number":4}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":122,"led":4}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2646,7 +2646,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":65,"led_number":5}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":65,"led":5}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2657,7 +2657,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":1,"led_level":100,"led_duration":30,"led_number":6}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":30,"led":6}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -5720,7 +5720,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -5881,7 +5881,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6040,7 +6040,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6051,7 +6051,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":170,"effect":255,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6219,7 +6219,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6378,7 +6378,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6531,7 +6531,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6542,7 +6542,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":170,"effect":255,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -7886,7 +7886,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Entryway/set',
       }),
       'domain': 'mqtt',
@@ -8088,7 +8088,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Entryway/set',
       }),
       'domain': 'mqtt',
@@ -8281,7 +8281,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Entryway/set',
       }),
       'domain': 'mqtt',
@@ -9127,7 +9127,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":90,"led_effect":1,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9138,7 +9138,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255}}',
+        'payload': '{"led_effect":{"color":170,"effect":255,"level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9306,7 +9306,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":0}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":0}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9317,7 +9317,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":25,"led_effect":1,"led_level":100,"led_duration":255,"led_number":1}}',
+        'payload': '{"individual_led_effect":{"color":25,"effect":1,"level":100,"duration":255,"led":1}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9328,7 +9328,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":255,"led_effect":1,"led_level":100,"led_duration":255,"led_number":2}}',
+        'payload': '{"individual_led_effect":{"color":255,"effect":1,"level":100,"duration":255,"led":2}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9339,7 +9339,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":3}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":3}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9350,7 +9350,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":25,"led_effect":1,"led_level":100,"led_duration":255,"led_number":4}}',
+        'payload': '{"individual_led_effect":{"color":25,"effect":1,"level":100,"duration":255,"led":4}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9361,7 +9361,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":255,"led_effect":1,"led_level":100,"led_duration":255,"led_number":5}}',
+        'payload': '{"individual_led_effect":{"color":255,"effect":1,"level":100,"duration":255,"led":5}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9372,7 +9372,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":6}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":6}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9383,7 +9383,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":0}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":0}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9394,7 +9394,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":1}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":1}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9405,7 +9405,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":3}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":3}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9416,7 +9416,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":4}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":4}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9427,7 +9427,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":6}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":6}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9438,7 +9438,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":2}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":2}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9449,7 +9449,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":5}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":5}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9682,7 +9682,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":0}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":0}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9693,7 +9693,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":25,"led_effect":1,"led_level":100,"led_duration":255,"led_number":1}}',
+        'payload': '{"individual_led_effect":{"color":25,"effect":1,"level":100,"duration":255,"led":1}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9704,7 +9704,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":255,"led_effect":1,"led_level":100,"led_duration":255,"led_number":2}}',
+        'payload': '{"individual_led_effect":{"color":255,"effect":1,"level":100,"duration":255,"led":2}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9715,7 +9715,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":3}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":3}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9726,7 +9726,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":25,"led_effect":1,"led_level":100,"led_duration":255,"led_number":4}}',
+        'payload': '{"individual_led_effect":{"color":25,"effect":1,"level":100,"duration":255,"led":4}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9737,7 +9737,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":255,"led_effect":1,"led_level":100,"led_duration":255,"led_number":5}}',
+        'payload': '{"individual_led_effect":{"color":255,"effect":1,"level":100,"duration":255,"led":5}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9748,7 +9748,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":0,"led_effect":1,"led_level":100,"led_duration":255,"led_number":6}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":6}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9759,7 +9759,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":1}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":1}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9770,7 +9770,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"led_color":170,"led_effect":255,"led_level":100,"led_duration":255,"led_number":4}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":4}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',

--- a/tests/snapshots/test_scenarios.ambr
+++ b/tests/snapshots/test_scenarios.ambr
@@ -911,7 +911,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":"open_close","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -922,7 +922,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -933,7 +933,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":"open_close","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1107,7 +1107,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":"open_close","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1118,7 +1118,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1129,7 +1129,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":"open_close","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1288,7 +1288,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":"open_close","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1299,7 +1299,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1310,7 +1310,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":"open_close","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -1469,7 +1469,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2424,7 +2424,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":0,"effect":6,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":0,"effect":"open_close","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2591,7 +2591,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":30,"led":0}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"solid","level":100,"duration":30,"led":0}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2602,7 +2602,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":65,"led":1}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"solid","level":100,"duration":65,"led":1}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2613,7 +2613,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":122,"led":2}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"solid","level":100,"duration":122,"led":2}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2624,7 +2624,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":30,"led":3}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"solid","level":100,"duration":30,"led":3}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2635,7 +2635,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":122,"led":4}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"solid","level":100,"duration":122,"led":4}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2646,7 +2646,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":65,"led":5}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"solid","level":100,"duration":65,"led":5}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -2657,7 +2657,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":1,"level":100,"duration":30,"led":6}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"solid","level":100,"duration":30,"led":6}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -5720,7 +5720,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -5881,7 +5881,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6040,7 +6040,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6051,7 +6051,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":170,"effect":255,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6219,7 +6219,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6378,7 +6378,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6531,7 +6531,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -6542,7 +6542,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":170,"effect":255,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -7886,7 +7886,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Entryway/set',
       }),
       'domain': 'mqtt',
@@ -8088,7 +8088,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Entryway/set',
       }),
       'domain': 'mqtt',
@@ -8281,7 +8281,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Entryway/set',
       }),
       'domain': 'mqtt',
@@ -9127,7 +9127,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":90,"effect":1,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":90,"effect":"solid","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9138,7 +9138,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"led_effect":{"color":170,"effect":255,"level":100,"duration":255}}',
+        'payload': '{"led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9306,7 +9306,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":0}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":"solid","level":100,"duration":255,"led":0}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9317,7 +9317,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":25,"effect":1,"level":100,"duration":255,"led":1}}',
+        'payload': '{"individual_led_effect":{"color":25,"effect":"solid","level":100,"duration":255,"led":1}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9328,7 +9328,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":255,"effect":1,"level":100,"duration":255,"led":2}}',
+        'payload': '{"individual_led_effect":{"color":255,"effect":"solid","level":100,"duration":255,"led":2}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9339,7 +9339,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":3}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":"solid","level":100,"duration":255,"led":3}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9350,7 +9350,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":25,"effect":1,"level":100,"duration":255,"led":4}}',
+        'payload': '{"individual_led_effect":{"color":25,"effect":"solid","level":100,"duration":255,"led":4}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9361,7 +9361,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":255,"effect":1,"level":100,"duration":255,"led":5}}',
+        'payload': '{"individual_led_effect":{"color":255,"effect":"solid","level":100,"duration":255,"led":5}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9372,7 +9372,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":6}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":"solid","level":100,"duration":255,"led":6}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9383,7 +9383,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":0}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255,"led":0}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9394,7 +9394,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":1}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255,"led":1}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9405,7 +9405,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":3}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255,"led":3}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9416,7 +9416,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":4}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255,"led":4}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9427,7 +9427,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":6}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255,"led":6}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9438,7 +9438,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":2}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255,"led":2}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9449,7 +9449,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":5}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255,"led":5}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9682,7 +9682,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":0}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":"solid","level":100,"duration":255,"led":0}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9693,7 +9693,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":25,"effect":1,"level":100,"duration":255,"led":1}}',
+        'payload': '{"individual_led_effect":{"color":25,"effect":"solid","level":100,"duration":255,"led":1}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9704,7 +9704,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":255,"effect":1,"level":100,"duration":255,"led":2}}',
+        'payload': '{"individual_led_effect":{"color":255,"effect":"solid","level":100,"duration":255,"led":2}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9715,7 +9715,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":3}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":"solid","level":100,"duration":255,"led":3}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9726,7 +9726,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":25,"effect":1,"level":100,"duration":255,"led":4}}',
+        'payload': '{"individual_led_effect":{"color":25,"effect":"solid","level":100,"duration":255,"led":4}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9737,7 +9737,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":255,"effect":1,"level":100,"duration":255,"led":5}}',
+        'payload': '{"individual_led_effect":{"color":255,"effect":"solid","level":100,"duration":255,"led":5}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9748,7 +9748,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":0,"effect":1,"level":100,"duration":255,"led":6}}',
+        'payload': '{"individual_led_effect":{"color":0,"effect":"solid","level":100,"duration":255,"led":6}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9759,7 +9759,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":1}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255,"led":1}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',
@@ -9770,7 +9770,7 @@
     ServiceCallSnapshot({
       'context': <ANY>,
       'data': ReadOnlyDict({
-        'payload': '{"individual_led_effect":{"color":170,"effect":255,"level":100,"duration":255,"led":4}}',
+        'payload': '{"individual_led_effect":{"color":170,"effect":"clear_effect","level":100,"duration":255,"led":4}}',
         'topic': 'home/z2m/Kitchen/set',
       }),
       'domain': 'mqtt',

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -87,11 +87,15 @@
 # ---
 # name: test_restore_state[missing_stored_data][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -99,7 +103,6 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
@@ -107,11 +110,15 @@
 # ---
 # name: test_restore_state[no_restore_for_sensor.kitchen_effect_brightness][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -119,7 +126,6 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
@@ -127,11 +133,15 @@
 # ---
 # name: test_restore_state[no_restore_for_sensor.kitchen_effect_color][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -139,7 +149,6 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
@@ -147,11 +156,15 @@
 # ---
 # name: test_restore_state[no_restore_for_sensor.kitchen_effect_duration][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -159,7 +172,6 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
@@ -167,11 +179,15 @@
 # ---
 # name: test_restore_state[no_restore_for_sensor.kitchen_effect_type][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
     ),
@@ -179,7 +195,6 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': None,
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
@@ -187,11 +202,15 @@
 # ---
 # name: test_restore_state[switch_info][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
       dict({
@@ -205,7 +224,6 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': 'doors_open',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
@@ -213,11 +231,15 @@
 # ---
 # name: test_restore_state[switch_info_for_override_service_call][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
       dict({
@@ -231,7 +253,6 @@
       'type': <LEDConfigSourceType.OVERRIDE: 'override'>,
       'value': 'lampie.override',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),
@@ -239,11 +260,15 @@
 # ---
 # name: test_restore_state[switch_info_with_numeric_color][switch_info]
   dict({
-    'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
     'expiration': ExpirationInfoSnapshot({
       'cancel_listener': None,
       'expires_at': None,
       'started_at': None,
+    }),
+    'integration': <Integration.ZHA: 'zha'>,
+    'integration_info': dict({
+      'disable_clear_notification_id': 'switch.kitchen_disable_config_2x_tap_to_clear_notifications',
+      'local_protection_id': 'switch.kitchen_local_protection',
     }),
     'led_config': tuple(
       dict({
@@ -257,7 +282,6 @@
       'type': <LEDConfigSourceType.NOTIFICATION: 'notification'>,
       'value': 'doors_open',
     }),
-    'local_protection_id': 'switch.kitchen_local_protection',
     'priorities': tuple(
       'doors_open',
     ),

--- a/tests/snapshots/test_services.ambr
+++ b/tests/snapshots/test_services.ambr
@@ -1,4 +1,114 @@
 # serializer version: 1
+# name: test_activate_service[full_led_config][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'individual': list([
+        100.0,
+        100.0,
+        100.0,
+        100.0,
+        100.0,
+        100.0,
+        100.0,
+      ]),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_activate_service[full_led_config][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+      'individual': list([
+        'green',
+        'orange',
+        'blue',
+        'yellow',
+        'pink',
+        'red',
+        'cyan',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'multi',
+  })
+# ---
+# name: test_activate_service[full_led_config][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'individual': list([
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+      ]),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_activate_service[full_led_config][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+      'individual': list([
+        'solid',
+        'solid',
+        'solid',
+        'solid',
+        'solid',
+        'solid',
+        'fast_blink',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'multi',
+  })
+# ---
+# name: test_activate_service[full_led_config][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'doors_open[custom]',
+  })
+# ---
 # name: test_activate_service[full_led_config][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -178,6 +288,80 @@
     }),
   ])
 # ---
+# name: test_activate_service[led_color][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_activate_service[led_color][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'green',
+  })
+# ---
+# name: test_activate_service[led_color][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_activate_service[led_color][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'solid',
+  })
+# ---
+# name: test_activate_service[led_color][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'doors_open[custom]',
+  })
+# ---
 # name: test_activate_service[led_color][switch.doors_open_notification]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -217,6 +401,80 @@
       'service': 'issue_zigbee_cluster_command',
     }),
   ])
+# ---
+# name: test_activate_service[notification_only][sensor.kitchen_effect_brightness]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect brightness',
+      'icon': 'mdi:brightness-percent',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100.0',
+  })
+# ---
+# name: test_activate_service[notification_only][sensor.kitchen_effect_color]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect color',
+      'icon': 'mdi:palette',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'red',
+  })
+# ---
+# name: test_activate_service[notification_only][sensor.kitchen_effect_duration]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect duration',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_activate_service[notification_only][sensor.kitchen_effect_type]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Effect type',
+      'icon': 'mdi:star-four-points-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_effect_type',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open_close',
+  })
+# ---
+# name: test_activate_service[notification_only][sensor.kitchen_notification]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kitchen Notification',
+      'icon': 'mdi:circle-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_notification',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'doors_open',
+  })
 # ---
 # name: test_activate_service[notification_only][switch.doors_open_notification]
   StateSnapshot({

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -218,6 +218,7 @@ async def test_primary_config_entry_sensor_ownership(
 
 async def test_mismatched_priorities_generate_warning(
     hass: HomeAssistant,
+    switch: er.RegistryEntry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that mismatched config priorities generate a warning."""

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,10 @@
+"""Lampie Orchestrator tests."""
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.lampie.orchestrator import LampieOrchestrator
+
+
+def test_teardown_without_setup(hass: HomeAssistant):
+    orchestrator = LampieOrchestrator(hass)
+    orchestrator.teardown()

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -7,14 +7,16 @@ import functools
 import logging
 import re
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+from homeassistant.components.mqtt import ReceiveMessage
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import Event, HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.json import json_dumps
 from homeassistant.setup import async_setup_component
-from homeassistant.util import slugify
+from homeassistant.util import dt as dt_util, slugify
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -38,7 +40,7 @@ from custom_components.lampie.const import (
     DOMAIN,
     TRACE,
 )
-from custom_components.lampie.orchestrator import LampieOrchestrator
+from custom_components.lampie.orchestrator import DATA_MQTT, LampieOrchestrator
 from custom_components.lampie.services import (
     SERVICE_NAME_ACTIVATE,
     SERVICE_NAME_OVERRIDE,
@@ -46,6 +48,7 @@ from custom_components.lampie.services import (
 from custom_components.lampie.types import (
     Color,
     Effect,
+    Integration,
     LEDConfig,
     LEDConfigSource,
     LEDConfigSourceType,
@@ -68,6 +71,15 @@ _LOGGER = logging.getLogger(__name__)
 type ANYType = _ANY
 
 
+_true_dict: dict[str, Any] = defaultdict(lambda: True)
+_false_dict: dict[str, Any] = defaultdict(lambda: False)
+
+
+@pytest.fixture(name="integration_overrides")
+def mock_integration_overrides() -> dict[str, Any]:
+    return {}
+
+
 @pytest.fixture(name="configs")
 def mock_configs() -> dict[str, Any]:
     return {}
@@ -81,6 +93,11 @@ def mock_initial_states() -> dict[str, str]:
 @pytest.fixture(name="scripts")
 def mock_scripts() -> dict[str, Any]:
     return {}
+
+
+@pytest.fixture(name="steps")
+def mock_steps() -> list[dict[str, Any]]:
+    return []
 
 
 @pytest.fixture(name="expected_states")
@@ -103,8 +120,8 @@ def mock_expected_service_calls() -> int | ANYType | None:
     return ANY
 
 
-@pytest.fixture(name="expected_zha_calls")
-def mock_expected_zha_calls() -> int | ANYType | None:
+@pytest.fixture(name="expected_cluster_commands")
+def mock_expected_cluster_commands() -> int | ANYType | None:
     return ANY
 
 
@@ -115,11 +132,12 @@ def mock_expected_log_messages() -> str | None:
 
 @pytest.fixture(name="snapshots")
 def mock_snapshots() -> dict[str, Any]:
-    return {}
+    return _true_dict
 
 
 async def _setup(
     hass: HomeAssistant,
+    integration_domain: Integration,
     configs: dict[str, dict[str, Any]],
     initial_states: dict[str, str],
     scripts: dict[str, Any],
@@ -133,10 +151,44 @@ async def _setup(
         scripts: A set of scripts to setup with the scripts integration.
 
         hass: Injected (do not configure in scenarios).
+        integration_domain: The domain for the tests being run.
         kwargs: Catchall for additional injected values.
     """
     configs = configs or {}  # ensure AbsentNone is converted to dict
     initial_states = initial_states or {}
+
+    # mock out services that send commands to the cluster right away since it's
+    # possible that these will be used during integration setup (i.e. Z2M makes
+    # requests for state information on `localProtection` and
+    # `doubleTapClearNotifications`).
+    zha_cluster_commands = async_mock_service(
+        hass, "zha", "issue_zigbee_cluster_command"
+    )
+    mqtt_publish_commands = async_mock_service(hass, "mqtt", "publish")
+
+    cluster_commands = {
+        Integration.ZHA: zha_cluster_commands,
+        Integration.Z2M: mqtt_publish_commands,
+    }[integration_domain]
+
+    # register the any additional switches needed from config entries.
+    for switch_id in {
+        switch_id
+        for config in configs.values()
+        for switch_id in config.get(CONF_SWITCH_ENTITIES, [])
+    }:
+        add_mock_switch(hass, switch_id, integration=integration_domain)
+
+    # register the any additional switches needed from `initial_states`.
+    for entity_id in initial_states:
+        if entity_id.startswith("light."):
+            add_mock_switch(hass, entity_id, integration=integration_domain)
+
+    # setup initial states
+    for entity_id, state in initial_states.items():
+        hass.states.async_set(entity_id, state)
+
+    # setup the standard config entry if it's being used.
     standard_config_entry: MockConfigEntry | None = kwargs.get("config_entry")
 
     if standard_config_entry is not None:
@@ -152,23 +204,6 @@ async def _setup(
         )
 
         await setup_added_integration(hass, standard_config_entry)
-
-    # register the any additional switches needed from config entries.
-    for switch_id in {
-        switch_id
-        for config in configs.values()
-        for switch_id in config.get(CONF_SWITCH_ENTITIES, [])
-    }:
-        add_mock_switch(hass, switch_id)
-
-    # register the any additional switches needed from `initial_states`.
-    for entity_id in initial_states:
-        if entity_id.startswith("light."):
-            add_mock_switch(hass, entity_id)
-
-    # setup initial states
-    for entity_id, state in initial_states.items():
-        hass.states.async_set(entity_id, state)
 
     # add config entries based on those in the config items.
     for config_key, config_data in configs.items():
@@ -189,8 +224,6 @@ async def _setup(
     if scripts is not None:
         assert await async_setup_component(hass, "script", {"script": scripts})
 
-    cluster_commands = async_mock_service(hass, "zha", "issue_zigbee_cluster_command")
-
     return {
         "_cluster_commands": cluster_commands,
     }
@@ -198,8 +231,11 @@ async def _setup(
 
 async def _steps(
     hass: HomeAssistant,
+    mqtt_subscribe: AsyncMock,
+    integration_domain: Integration,
     now: MockNow,
     steps: list[dict[str, Any]],
+    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     **kwargs: Any,
 ) -> dict[str, Any]:
@@ -209,7 +245,10 @@ async def _steps(
         steps: A list of mappings.
 
         hass: Injected (do not configure in scenarios).
+        mqtt_subscribe: The mock for MQTT subscriptions.
+        integration_domain: The domain for the tests being run.
         now: Injected (do not configure in scenarios).
+        device_registry: Injected (do not configure in scenarios).
         entity_registry: Injected (do not configure in scenarios).
         kwargs: Catchall for additional injected values.
     """
@@ -237,15 +276,24 @@ async def _steps(
             _LOGGER.log(TRACE, "step %r", step)
 
             if "device_config" in step:
-                _step_device_config(step=step, hass=hass)
-            elif "action" in step:
+                step = (
+                    _step_device_config(
+                        step=step, integration_domain=integration_domain, hass=hass
+                    )
+                    or {}
+                )
+
+            if "action" in step:
                 await _step_action(step=step, async_call=async_call)
             elif "event" in step:
-                _step_event(
+                await _step_event(
                     step=step,
+                    integration_domain=integration_domain,
                     hass=hass,
                     standard_switch=standard_switch,
+                    device_registry=device_registry,
                     entity_registry=entity_registry,
+                    mqtt_subscribe=mqtt_subscribe,
                 )
             elif "delay" in step:
                 now._tick(step["delay"].total_seconds())
@@ -257,7 +305,11 @@ async def _steps(
             (domain, service, args, *rest)
             for call in mocked_service_call.mock_calls
             for domain, service, args, *rest in [call.args]
-            if (domain, service) != ("zha", "issue_zigbee_cluster_command")
+            if (domain, service)
+            not in {
+                ("zha", "issue_zigbee_cluster_command"),
+                ("mqtt", "publish"),
+            }
         ]
 
     return {
@@ -269,12 +321,34 @@ async def _steps(
 def _step_device_config(
     *,
     step: dict[str, Any],
+    integration_domain: Integration,
     hass: HomeAssistant,
-) -> None:
+) -> dict[str, Any] | None:
     """Scenario stage helper function for a device configuration step.
 
     Args:
         step: Details for configuring the target device.
+        integration_domain: The integration domain.
+        hass: Home Assistant instance.
+
+    Return:
+        An alternative type of step that performs the necessary device config.
+    """
+    return {
+        Integration.ZHA: _step_zha_device_config,
+        Integration.Z2M: _step_z2m_device_config,
+    }[integration_domain](step=step, hass=hass)
+
+
+def _step_zha_device_config(
+    *,
+    step: dict[str, Any],
+    hass: HomeAssistant,
+) -> None:
+    """Scenario stage helper function for device config step.
+
+    Args:
+        step: A step for configuring the target device.
         hass: Home Assistant instance.
     """
     device_config = step["device_config"]
@@ -296,6 +370,41 @@ def _step_device_config(
             disable_clear_notification_id,
             device_config["disable_clear_notification"],
         )
+
+
+def _step_z2m_device_config(
+    *,
+    step: dict[str, Any],
+    hass: HomeAssistant,
+) -> dict[str, Any]:
+    """Scenario stage helper function for device config step.
+
+    Args:
+        step: A step for configuring the target device.
+        hass: Home Assistant instance.
+    """
+    device_config = step["device_config"]
+    target = device_config["target"]
+    payload = {}
+
+    if "local_protection" in device_config:
+        payload["localProtection"] = (
+            "Enabled" if device_config["local_protection"] == "on" else "Disabled"
+        )
+
+    if "disable_clear_notification" in device_config:
+        payload["doubleTapClearNotifications"] = (
+            "Disabled"
+            if device_config["disable_clear_notification"] == "on"
+            else "Enabled"
+        )
+
+    return {
+        "event": {
+            "entity_id": target,
+            "payload": payload,
+        }
+    }
 
 
 async def _step_action(
@@ -321,12 +430,48 @@ async def _step_action(
     )
 
 
-def _step_event(
+async def _step_event(
+    *,
+    step: dict[str, Any],
+    integration_domain: Integration,
+    hass: HomeAssistant,
+    standard_switch: er.RegistryEntry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    **kwargs: Any,
+) -> None:
+    """Scenario stage helper function for a step that simulates an event.
+
+    Args:
+        step: A step for configuring the target device.
+        integration_domain: The integration domain.
+        hass: Home Assistant instance.
+        standard_switch: Switch for the standard config entry.
+        device_registry: The device registry.
+        entity_registry: The entity registry.
+        kwargs: Additional values (allowing variation between integrations).
+    """
+    await {
+        Integration.ZHA: _step_zha_event,
+        Integration.Z2M: _step_z2m_event,
+    }[integration_domain](
+        step=step,
+        hass=hass,
+        standard_switch=standard_switch,
+        device_registry=device_registry,
+        entity_registry=entity_registry,
+        **kwargs,
+    )
+
+
+async def _step_zha_event(  # noqa: RUF029
     *,
     step: dict[str, Any],
     hass: HomeAssistant,
     standard_switch: er.RegistryEntry,
+    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    **kwargs: Any,
 ) -> None:
     """Scenario stage helper function for a step that simulates an event.
 
@@ -334,7 +479,9 @@ def _step_event(
         step: A step for configuring the target device.
         hass: Home Assistant instance.
         standard_switch: Switch for the standard config entry.
+        device_registry: The device registry.
         entity_registry: The entity registry.
+        kwargs: Additional values (allowing variation between integrations).
     """
     event_data = {**step["event"]}
     entity_id = event_data.pop("entity_id", None)
@@ -353,8 +500,82 @@ def _step_event(
     )
 
 
+async def _step_z2m_event(
+    *,
+    step: dict[str, Any],
+    hass: HomeAssistant,
+    standard_switch: er.RegistryEntry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    **kwargs: Any,
+) -> None:
+    """Scenario stage helper function for a step that simulates an event.
+
+    Args:
+        step: A step for configuring the target device.
+        hass: Home Assistant instance.
+        standard_switch: Switch for the standard config entry.
+        device_registry: The device registry.
+        entity_registry: The entity registry.
+        kwargs: Additional values (allowing variation between integrations).
+    """
+    event_data = {**step["event"]}
+    entity_id = event_data.pop("entity_id", None)
+    device_id = standard_switch.device_id if standard_switch is not None else None
+
+    # if supplied, get the device related to the entity_id instead
+    if entity_id is not None:
+        device_id = entity_registry.async_get(entity_id).device_id
+
+    command = event_data.pop("command", None)
+    payload = {**event_data.pop("payload", {})}
+    mqtt_subscribe: AsyncMock = kwargs["mqtt_subscribe"]
+    subscribe_calls = mqtt_subscribe.mock_calls
+    last_subscribe_call = subscribe_calls[-1]
+    _, subscribed_topic, callback, *_rest = last_subscribe_call.args
+
+    assert subscribed_topic == "home/z2m/+"
+
+    # `add_mock_switch` matches `device.name` & MQTT device name, so
+    # just get the device name from the entity_id given in the
+    # scenario.
+    device = device_registry.async_get(device_id)
+    device_name = device.name
+
+    topic = event_data.pop("topic", f"home/z2m/{device_name}")
+    action = {
+        "button_3_double": "config_double",
+    }.get(command)
+
+    if command and command.startswith("led_effect_complete_"):
+        notification_complete = re.sub(r"^led_effect_complete_", "", command)
+    else:
+        notification_complete = None
+
+    if action:
+        payload["action"] = action
+    elif notification_complete:
+        payload["notificationComplete"] = notification_complete
+    elif not payload:
+        payload["action"] = f"unsupported_action_{command}"
+
+    _LOGGER.debug("publishing to %s: %s", topic, payload)
+    await callback(
+        ReceiveMessage(
+            topic=topic,
+            payload=json_dumps(payload),
+            qos=0,
+            retain=False,
+            subscribed_topic=topic,
+            timestamp=dt_util.utcnow(),
+        )
+    )
+
+
 async def _assert_expectations(  # noqa: RUF029
     hass: HomeAssistant,
+    integration_domain: Integration,
+    integration_overrides: dict[str, Any],
     configs: dict[str, dict[str, Any]],
     initial_states: dict[str, str],
     _cluster_commands: list[Any],
@@ -364,11 +585,11 @@ async def _assert_expectations(  # noqa: RUF029
     expected_timers: dict[str, bool],
     expected_events: int | ANYType | None,
     expected_service_calls: int | ANYType | None,
-    expected_zha_calls: int | ANYType | None,
+    expected_cluster_commands: int | ANYType | None,
     expected_log_messages: str | AbsentNone | None,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
-    snapshots: dict[str, Any],
+    snapshots: dict[str, Any] | AbsentNone,
     caplog: pytest.LogCaptureFixture,
     **kwargs: Any,
 ) -> dict[str, Any]:
@@ -376,6 +597,9 @@ async def _assert_expectations(  # noqa: RUF029
 
     Args:
         configs: See `_setup`.
+        integration_domain: The domain for the tests being run.
+        integration_overrides: Overrides to apply to expectations/snapshots.
+            Mappings are merged & other values are simply replaced.
         initial_states: See `_setup`.
         expected_states: Mapping of entity ID to state value.
         expected_timers: Mapping of `notification|slug` or `switch|entity_id` to
@@ -388,10 +612,10 @@ async def _assert_expectations(  # noqa: RUF029
             service calls that are for sending messages to the device cluster.
             So it's usually just asserting against the `script` invocations used
             for start/end actions.
-        expected_zha_calls: Number of expected service calls into the device
-            cluster (or ANY to simply snapshot).
+        expected_cluster_commands: Number of expected service calls into the
+            device cluster (or ANY to simply snapshot).
         expected_log_messages: Message to check to ensure it's logged.
-        snapshots: A mapping for what to snapshot with the following keys:
+        snapshots: A mapping for what to snapshot with the required keys:
             configs (default=`True`):  A boolean (reused for all config entries)
                 or a mapping from config entry slugs to one of `bool`,
                 `"standard_info"` or `"entities"`. `"standard_info"` will
@@ -414,25 +638,61 @@ async def _assert_expectations(  # noqa: RUF029
         caplog: Injected (do not configure in scenarios).
         kwargs: Catchall for additional injected values.
     """
-    configs = configs or {}  # ensure AbsentNone is converted to dict
+    # ensure AbsentNone is converted to dict
+    configs = configs or {}
+    expected_states = expected_states or {}
+
+    # apply overrides to test inputs
+    overrides = (integration_overrides or {}).get(integration_domain, {})
+
+    if "expected_states" in overrides:
+        expected_states = {**expected_states, **overrides["expected_states"]}
+    if "expected_timers" in overrides:
+        expected_timers = {**expected_timers, **overrides["expected_timers"]}
+    if "expected_events" in overrides:
+        expected_events = overrides["expected_events"]
+    if "expected_service_calls" in overrides:
+        expected_service_calls = overrides["expected_service_calls"]
+    if "expected_cluster_commands" in overrides:
+        expected_cluster_commands = overrides["expected_cluster_commands"]
+    if "expected_log_messages" in overrides:
+        expected_log_messages = overrides["expected_log_messages"]
+    if "snapshots" in overrides:
+        snapshots = overrides["snapshots"]
+
+    # z2m always does an extra call to request state, so handle the
+    # non-overridden cases by incrementing the expectation by one to avoid
+    # having to always override it.
+    if (
+        "expected_cluster_commands" not in overrides
+        and isinstance(expected_cluster_commands, int)
+        and integration_domain == Integration.Z2M
+    ):
+        expected_cluster_commands += 1
+
+    # only snapshot by default for ZHA
+    if snapshots == Scenario.ABSENT:
+        snapshots_default = integration_domain == Integration.ZHA
+        snapshots = defaultdict(lambda: snapshots_default)
+
     standard_config_entry: MockConfigEntry | None = kwargs.get("config_entry")
     standard_switch: er.RegistryEntry | None = kwargs.get("switch")
     orchestrator: LampieOrchestrator = hass.data[DOMAIN]
 
-    snapshot_configs = snapshots.get("configs", True)
-    snapshot_switches = snapshots.get("switches", True)
-    snapshot_events = snapshots.get("events", True)
-    snapshot_service_calls = snapshots.get("service_calls", True)
-    snapshot_cluster_commands = snapshots.get("cluster_commands", True)
+    snapshot_configs = snapshots["configs"]
+    snapshot_switches = snapshots["switches"]
+    snapshot_events = snapshots["events"]
+    snapshot_service_calls = snapshots["service_calls"]
+    snapshot_cluster_commands = snapshots["cluster_commands"]
 
     if isinstance(snapshot_configs, bool):
-        value = snapshot_configs
-        snapshot_configs = defaultdict(lambda: value)
+        snapshot_configs_default = snapshot_configs
+        snapshot_configs = defaultdict(lambda: snapshot_configs_default)
 
     if (
         standard_config_entry is not None
         and standard_switch is not None
-        and snapshot_configs.get("doors_open", True) in {True, "standard_info"}
+        and snapshot_configs["doors_open"] in {True, "standard_info"}
     ):
         notification_info = orchestrator.notification_info("doors_open")
         switch_info = orchestrator.switch_info(standard_switch.entity_id)
@@ -448,8 +708,10 @@ async def _assert_expectations(  # noqa: RUF029
             name="service_calls", matcher=any_device_id_matcher
         )
 
-    if expected_zha_calls and snapshot_cluster_commands:
-        assert _cluster_commands == snapshot(name="zha_cluster_commands")
+    if expected_cluster_commands and snapshot_cluster_commands:
+        assert _cluster_commands == snapshot(
+            name=f"{integration_domain}_cluster_commands"
+        )
 
     # assert switch info against internal state to avoid creating the switch
     # info: this allows some test cases to assert that the orchestrator
@@ -467,7 +729,7 @@ async def _assert_expectations(  # noqa: RUF029
         for entity in entity_registry.entities.get_entries_for_config_entry_id(
             entry.entry_id
         )
-        if snapshot_configs.get(slugify(entry.title), True) in {True, "entities"}
+        if snapshot_configs[slugify(entry.title)] in {True, "entities"}
     ):
         assert hass.states.get(entity.entity_id) == snapshot(name=entity.entity_id)
 
@@ -507,9 +769,9 @@ async def _assert_expectations(  # noqa: RUF029
             f"expected {expected_service_calls} services calls (usually script invocations)"
         )
 
-    if expected_zha_calls not in {None, Scenario.ABSENT, ANY}:
-        assert len(_cluster_commands) == expected_zha_calls, (
-            f"expected {expected_zha_calls} cluster command service calls"
+    if expected_cluster_commands not in {None, Scenario.ABSENT, ANY}:
+        assert len(_cluster_commands) == expected_cluster_commands, (
+            f"expected {expected_cluster_commands} cluster command service calls"
         )
 
     if expected_log_messages not in {None, Scenario.ABSENT}:
@@ -559,7 +821,7 @@ def _response_script(name: str, response: dict[str, Any]) -> dict[str, Any]:
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 1,
+            "expected_cluster_commands": 1,
         },
     ),
     Scenario(
@@ -591,13 +853,14 @@ def _response_script(name: str, response: dict[str, Any]) -> dict[str, Any]:
                 {"event": {"command": "led_effect_complete_LED_3"}},
                 {"event": {"command": "led_effect_complete_LED_5"}},
             ],
+            "snapshots": _true_dict,
             "expected_states": {"switch.doors_open_notification": "off"},
             "expected_timers": {
                 "notification|doors_open": False,
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 7,
+            "expected_cluster_commands": 7,
         },
     ),
     Scenario(
@@ -619,8 +882,9 @@ def _response_script(name: str, response: dict[str, Any]) -> dict[str, Any]:
                 "notification|doors_open": True,
                 "switch|light.kitchen": False,
             },
+            "snapshots": _true_dict,
             "expected_events": 0,
-            "expected_zha_calls": 1,
+            "expected_cluster_commands": 1,
         },
     ),
     Scenario(
@@ -644,7 +908,7 @@ def _response_script(name: str, response: dict[str, Any]) -> dict[str, Any]:
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 2,
+            "expected_cluster_commands": 2,
         },
     ),
     Scenario(
@@ -676,7 +940,7 @@ def _response_script(name: str, response: dict[str, Any]) -> dict[str, Any]:
                 "switch|light.kitchen": False,
             },
             "expected_events": 0,
-            "expected_zha_calls": 9,
+            "expected_cluster_commands": 9,
         },
     ),
     Scenario(
@@ -709,7 +973,7 @@ def _response_script(name: str, response: dict[str, Any]) -> dict[str, Any]:
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 14,
+            "expected_cluster_commands": 14,
         },
     ),
     Scenario(
@@ -733,7 +997,38 @@ def _response_script(name: str, response: dict[str, Any]) -> dict[str, Any]:
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 1,
+            "expected_cluster_commands": 1,
+        },
+    ),
+    Scenario(
+        "doors_open_5m1s_dismissed_local_protection_and_2x_tap_dismissal_enabled",
+        {
+            "configs": {
+                "doors_open": {
+                    CONF_DURATION: dt.timedelta(minutes=5, seconds=1).total_seconds()
+                }
+            },
+            "steps": [
+                {
+                    "device_config": {
+                        "target": "light.kitchen",
+                        "local_protection": "on",
+                        "disable_clear_notification": "off",
+                    },
+                },
+                {
+                    "action": f"{SWITCH_DOMAIN}.{SERVICE_TURN_ON}",
+                    "target": "switch.doors_open_notification",
+                },
+                {"event": {"command": "button_3_double"}},
+            ],
+            "expected_states": {"switch.doors_open_notification": "off"},
+            "expected_timers": {
+                "notification|doors_open": False,
+                "switch|light.kitchen": False,
+            },
+            "expected_events": 1,
+            "expected_cluster_commands": 2,
         },
     ),
     Scenario(
@@ -760,7 +1055,7 @@ def _response_script(name: str, response: dict[str, Any]) -> dict[str, Any]:
                 "switch|light.kitchen": False,
             },
             "expected_events": 0,
-            "expected_zha_calls": 2,
+            "expected_cluster_commands": 2,
         },
     ),
     Scenario(
@@ -789,7 +1084,7 @@ def _response_script(name: str, response: dict[str, Any]) -> dict[str, Any]:
                 "switch|light.kitchen": False,
             },
             "expected_events": 0,
-            "expected_zha_calls": 1,
+            "expected_cluster_commands": 1,
         },
     ),
     Scenario(
@@ -815,7 +1110,7 @@ def _response_script(name: str, response: dict[str, Any]) -> dict[str, Any]:
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 2,
+            "expected_cluster_commands": 2,
         },
     ),
     Scenario(
@@ -836,15 +1131,27 @@ def _response_script(name: str, response: dict[str, Any]) -> dict[str, Any]:
                 },
                 {"event": {"command": "button_3_double"}},
             ],
+            "integration_overrides": {
+                Integration.Z2M: {
+                    "expected_cluster_commands": 5,  # 2 switches setup + normal expectation
+                },
+            },
             "expected_states": {"switch.doors_open_notification": "off"},
             "expected_timers": {
                 "notification|doors_open": False,
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 3,
+            "expected_cluster_commands": 3,
         },
     ),
+)
+@pytest.mark.parametrize(
+    "integration_domain",
+    [
+        Integration.ZHA,
+        Integration.Z2M,
+    ],
 )
 @scenario_stages(standard_config_entry=True)
 async def test_single_config_entry(
@@ -881,7 +1188,7 @@ async def test_single_config_entry(
                 "switch|light.kitchen": False,
             },
             "expected_events": 0,
-            "expected_zha_calls": 1,
+            "expected_cluster_commands": 1,
         },
     ),
     Scenario(
@@ -912,7 +1219,7 @@ async def test_single_config_entry(
                 "switch|light.kitchen": False,
             },
             "expected_events": 0,
-            "expected_zha_calls": 2,
+            "expected_cluster_commands": 2,
         },
     ),
     Scenario(
@@ -943,7 +1250,7 @@ async def test_single_config_entry(
                 "switch|light.kitchen": False,
             },
             "expected_events": 0,
-            "expected_zha_calls": 2,
+            "expected_cluster_commands": 2,
         },
     ),
     Scenario(
@@ -968,7 +1275,7 @@ async def test_single_config_entry(
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 1,
+            "expected_cluster_commands": 1,
         },
     ),
     Scenario(
@@ -992,7 +1299,7 @@ async def test_single_config_entry(
                 "switch|light.kitchen": True,
             },
             "expected_events": 0,
-            "expected_zha_calls": 1,
+            "expected_cluster_commands": 1,
         },
     ),
     Scenario(
@@ -1017,9 +1324,16 @@ async def test_single_config_entry(
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 1,
+            "expected_cluster_commands": 1,
         },
     ),
+)
+@pytest.mark.parametrize(
+    "integration_domain",
+    [
+        Integration.ZHA,
+        Integration.Z2M,
+    ],
 )
 @scenario_stages(standard_config_entry=True)
 async def test_switch_override(
@@ -1059,7 +1373,7 @@ async def test_switch_override(
                 "switch|light.kitchen": False,
             },
             "expected_events": 0,
-            "expected_zha_calls": 1,
+            "expected_cluster_commands": 1,
         },
     ),
     Scenario(
@@ -1094,7 +1408,7 @@ async def test_switch_override(
                 "switch|light.kitchen": False,
             },
             "expected_events": 0,
-            "expected_zha_calls": 3,
+            "expected_cluster_commands": 3,
         },
     ),
     Scenario(
@@ -1123,7 +1437,7 @@ async def test_switch_override(
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 3,
+            "expected_cluster_commands": 3,
         },
     ),
     Scenario(
@@ -1152,9 +1466,16 @@ async def test_switch_override(
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 3,
+            "expected_cluster_commands": 3,
         },
     ),
+)
+@pytest.mark.parametrize(
+    "integration_domain",
+    [
+        Integration.ZHA,
+        Integration.Z2M,
+    ],
 )
 @scenario_stages(standard_config_entry=True)
 async def test_enable_notification_with_switch_override(
@@ -1191,7 +1512,7 @@ async def test_enable_notification_with_switch_override(
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 2,
+            "expected_cluster_commands": 2,
         },
     ),
     Scenario(
@@ -1222,7 +1543,7 @@ async def test_enable_notification_with_switch_override(
                 "switch|light.kitchen": True,
             },
             "expected_events": 0,
-            "expected_zha_calls": 9,
+            "expected_cluster_commands": 9,
         },
     ),
     Scenario(
@@ -1254,9 +1575,16 @@ async def test_enable_notification_with_switch_override(
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 14,
+            "expected_cluster_commands": 14,
         },
     ),
+)
+@pytest.mark.parametrize(
+    "integration_domain",
+    [
+        Integration.ZHA,
+        Integration.Z2M,
+    ],
 )
 @scenario_stages(standard_config_entry=True)
 async def test_switch_override_with_duration_expired(
@@ -1289,13 +1617,56 @@ async def test_switch_override_with_duration_expired(
                     },
                 },
             ],
+            "integration_overrides": {
+                Integration.Z2M: {
+                    "expected_cluster_commands": 3,  # 2 switches setup + normal expectation
+                },
+            },
             "expected_states": {"switch.doors_open_notification": "off"},
             "expected_timers": {
                 "notification|doors_open": False,
                 "switch|light.kitchen": False,
             },
             "expected_events": 0,
-            "expected_zha_calls": 1,
+            "expected_cluster_commands": 1,
+        },
+    ),
+    Scenario(
+        "entryway_override_unrelated_command",
+        {
+            "configs": {},
+            "initial_states": {
+                "light.entryway": "on",
+            },
+            "steps": [
+                {
+                    "action": f"{DOMAIN}.{SERVICE_NAME_OVERRIDE}",
+                    "target": "light.entryway",
+                    "data": {
+                        ATTR_LED_CONFIG: [
+                            {ATTR_COLOR: "green"},
+                        ],
+                    },
+                },
+                {
+                    "event": {
+                        "command": "unrelated",  # something we ignore
+                        "entity_id": "light.entryway",
+                    },
+                },
+            ],
+            "integration_overrides": {
+                Integration.Z2M: {
+                    "expected_cluster_commands": 3,  # 2 switches setup + normal expectation
+                },
+            },
+            "expected_states": {"switch.doors_open_notification": "off"},
+            "expected_timers": {
+                "notification|doors_open": False,
+                "switch|light.kitchen": False,
+            },
+            "expected_events": 0,
+            "expected_cluster_commands": 1,
         },
     ),
     Scenario(
@@ -1322,13 +1693,18 @@ async def test_switch_override_with_duration_expired(
                     },
                 },
             ],
+            "integration_overrides": {
+                Integration.Z2M: {
+                    "expected_cluster_commands": 3,  # 2 switches setup + normal expectation
+                },
+            },
             "expected_states": {"switch.doors_open_notification": "off"},
             "expected_timers": {
                 "notification|doors_open": False,
                 "switch|light.kitchen": False,
             },
             "expected_events": 1,
-            "expected_zha_calls": 1,
+            "expected_cluster_commands": 1,
         },
     ),
     Scenario(
@@ -1352,9 +1728,16 @@ async def test_switch_override_with_duration_expired(
                 "switch|light.kitchen": False,
             },
             "expected_events": 0,
-            "expected_zha_calls": 0,
+            "expected_cluster_commands": 0,
         },
     ),
+)
+@pytest.mark.parametrize(
+    "integration_domain",
+    [
+        Integration.ZHA,
+        Integration.Z2M,
+    ],
 )
 @scenario_stages(standard_config_entry=True)
 async def test_switch_override_on_unrelated_switch(
@@ -1571,7 +1954,8 @@ _TOGGLE_NOTIFICATION_WITH_ACTIONS_CONFIGS = {
 }
 
 _TOGGLE_NOTIFICATION_WITH_ACTIONS_SNAPSHOTS = {
-    "configs": {
+    "configs": _true_dict
+    | {
         "doors_open": "entities",
         "windows_open": False,
     }
@@ -1579,7 +1963,7 @@ _TOGGLE_NOTIFICATION_WITH_ACTIONS_SNAPSHOTS = {
 
 _TOGGLE_NOTIFICATION_WITH_ACTIONS_BASE = {
     "expected_events": None,
-    "snapshots": _TOGGLE_NOTIFICATION_WITH_ACTIONS_SNAPSHOTS,
+    "snapshots": _true_dict | _TOGGLE_NOTIFICATION_WITH_ACTIONS_SNAPSHOTS,
 }
 
 
@@ -1744,14 +2128,15 @@ async def test_toggle_notification_with_actions(
 
 
 _DISMISSAL_FROM_SWITCH_SNAPSHOTS = {
-    "configs": {
+    "configs": _true_dict
+    | {
         "doors_open": False,
     },
     "events": False,
 }
 
 _DISMISSAL_FROM_SWITCH_BASE = {
-    "snapshots": _DISMISSAL_FROM_SWITCH_SNAPSHOTS,
+    "snapshots": _true_dict | _DISMISSAL_FROM_SWITCH_SNAPSHOTS,
 }
 
 
@@ -1764,7 +2149,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
             "steps": [{"event": {"command": "led_effect_complete_ALL_LEDS"}}],
             "expected_notification_state": "off",
             "expected_leds_on": [],
-            "expected_zha_calls": 0,
+            "expected_cluster_commands": 0,
         },
     ),
     Scenario(
@@ -1781,7 +2166,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
             "steps": [{"event": {"command": "led_effect_complete_ALL_LEDS"}}],
             "expected_notification_state": "off",
             "expected_leds_on": [],
-            "expected_zha_calls": 0,
+            "expected_cluster_commands": 0,
         },
     ),
     Scenario(
@@ -1795,7 +2180,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
             "steps": [{"event": {"command": "led_effect_complete_ALL_LEDS"}}],
             "expected_notification_state": "off",
             "expected_leds_on": [],
-            "expected_zha_calls": 0,
+            "expected_cluster_commands": 0,
         },
     ),
     Scenario(
@@ -1806,7 +2191,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
             "steps": [{"event": {"command": "led_effect_complete_ALL_LEDS"}}],
             "expected_notification_state": "off",
             "expected_leds_on": [],
-            "expected_zha_calls": 0,
+            "expected_cluster_commands": 0,
         },
     ),
     Scenario(
@@ -1817,7 +2202,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
             "steps": [{"event": {"command": "led_effect_complete_LED_1"}}],
             "expected_notification_state": "on",
             "expected_leds_on": [False] + [True] * 6,
-            "expected_zha_calls": 0,
+            "expected_cluster_commands": 0,
         },
     ),
     Scenario(
@@ -1828,7 +2213,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
             "steps": [{"event": {"command": "led_effect_complete_LED_7"}}],
             "expected_notification_state": "on",
             "expected_leds_on": [True],
-            "expected_zha_calls": 0,
+            "expected_cluster_commands": 0,
             "expected_log_messages": (
                 "could not clear switch config at index 6 on light.kitchen"
             ),
@@ -1849,7 +2234,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     "steps": [{"event": {"command": command}}],
                     "expected_notification_state": "off",
                     "expected_leds_on": [],
-                    "expected_zha_calls": 0,
+                    "expected_cluster_commands": 0,
                 },
             ),
             Scenario(
@@ -1868,7 +2253,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     "steps": [{"event": {"command": command}}],
                     "expected_notification_state": "on",
                     "expected_leds_on": [True],
-                    "expected_zha_calls": 1,
+                    "expected_cluster_commands": 1,
                 },
             ),
             Scenario(
@@ -1885,7 +2270,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     "steps": [{"event": {"command": command}}],
                     "expected_notification_state": "off",
                     "expected_leds_on": [],
-                    "expected_zha_calls": 0,
+                    "expected_cluster_commands": 0,
                 },
             ),
             Scenario(
@@ -1896,7 +2281,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     "steps": [{"event": {"command": command}}],
                     "expected_notification_state": "off",
                     "expected_leds_on": [],
-                    "expected_zha_calls": 0,
+                    "expected_cluster_commands": 0,
                 },
             ),
             Scenario(
@@ -1911,7 +2296,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     "steps": [{"event": {"command": command}}],
                     "expected_notification_state": "off",
                     "expected_leds_on": [],
-                    "expected_zha_calls": 0,
+                    "expected_cluster_commands": 0,
                 },
             ),
             Scenario(
@@ -1929,7 +2314,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     "expected_led_config_source": LEDConfigSource(
                         "doors_open", LEDConfigSourceType.NOTIFICATION
                     ),
-                    "expected_zha_calls": 1,
+                    "expected_cluster_commands": 1,
                 },
             ),
             Scenario(
@@ -1961,8 +2346,8 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     ],
                     "expected_notification_state": "on",
                     "expected_leds_on": [True],
-                    "expected_zha_calls": 2,  # display medicine, re-display doors_open
-                    "snapshots": {},
+                    "expected_cluster_commands": 2,  # display medicine, re-display doors_open
+                    "snapshots": _true_dict,
                 },
             ),
             Scenario(
@@ -1975,7 +2360,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     "expected_notification_state": "on",
                     "expected_leds_on": [True],
                     "expected_led_config_source": None,
-                    "expected_zha_calls": 0,
+                    "expected_cluster_commands": 0,
                     "expected_log_messages": (
                         "missing LED config and/or source for dismissal on switch light.kitchen; "
                         f"skipping processing ZHA event {command}"
@@ -1993,7 +2378,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     "steps": [{"event": {"command": command}}],
                     "expected_notification_state": "off",
                     "expected_leds_on": [],
-                    "expected_zha_calls": 1,
+                    "expected_cluster_commands": 1,
                 },
             ),
             Scenario(
@@ -2015,7 +2400,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     "steps": [{"event": {"command": command}}],
                     "expected_notification_state": "on",
                     "expected_leds_on": [True],
-                    "expected_zha_calls": 0,
+                    "expected_cluster_commands": 0,
                 },
             ),
             Scenario(
@@ -2030,7 +2415,7 @@ _DISMISSAL_FROM_SWITCH_BASE = {
                     "steps": [{"event": {"command": command}}],
                     "expected_notification_state": "on",
                     "expected_leds_on": [True],
-                    "expected_zha_calls": 0,
+                    "expected_cluster_commands": 0,
                 },
             ),
         ]
@@ -2111,3 +2496,75 @@ async def test_dismissal_from_switch(
     switch_info = orchestrator.switch_info(standard_switch.entity_id)
     assert switch_info.led_config == expected_led_config
     assert switch_info.led_config_source == expected_led_config_source
+
+
+@Scenario.parametrize(
+    Scenario(
+        "mqtt_wait_for_client_failure",
+        {
+            "integration_domain": Integration.Z2M,
+            "mqtt_wait_for_client_return_value": False,
+            "steps": [],
+            "snapshots": _false_dict,
+            "expected_log_messages": "MQTT integration is not available",
+        },
+    ),
+    Scenario(
+        "mqtt_debug_info_entities_failure",
+        {
+            "integration_domain": Integration.Z2M,
+            "mqtt_debug_info_entities": {},
+            "steps": [],
+            "snapshots": _false_dict,
+            "expected_log_messages": (
+                "failed to determine MQTT topic from internal HASS state for "
+                "light.kitchen. using default of zigbee2mqtt/Kitchen from "
+                "device name"
+            ),
+        },
+    ),
+    Scenario(
+        "mqtt_message_payload_topic_mismatch",
+        {
+            "integration_domain": Integration.Z2M,
+            "steps": [
+                {
+                    "action": f"{SWITCH_DOMAIN}.{SERVICE_TURN_ON}",
+                    "target": "switch.doors_open_notification",
+                },
+                {
+                    "event": {
+                        "topic": "zigbee2mqtt/Kitchen",
+                        "payload": {
+                            "action": "config_double",
+                        },
+                    }
+                },
+            ],
+            "snapshots": _false_dict,
+            "expected_states": {"switch.doors_open_notification": "on"},
+            "expected_events": 0,
+            "expected_cluster_commands": 1,
+        },
+    ),
+)
+@scenario_stages(standard_config_entry=True)
+async def test_z2m_scenario(
+    setup: ScenarioStageWrapper,
+    steps_callback: ScenarioStageWrapper,
+    assert_expectations: ScenarioStageWrapper,
+    *,
+    hass: HomeAssistant,
+    mqtt: dict[str, Any],
+    mqtt_wait_for_client_return_value: bool | AbsentNone,
+    mqtt_debug_info_entities: dict[str, Any] | AbsentNone,
+    **kwargs: Any,
+):
+    if mqtt_wait_for_client_return_value != Scenario.ABSENT:
+        mqtt["wait_for_mqtt_client"].return_value = mqtt_wait_for_client_return_value
+    if mqtt_debug_info_entities != Scenario.ABSENT:
+        hass.data[DATA_MQTT].debug_info_entities = mqtt_debug_info_entities
+
+    await setup()
+    await steps_callback()
+    await assert_expectations()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -172,8 +172,7 @@ RESTORE_STATE_SCENARIOS = (
                     ),
                 ),
                 led_config_source=LEDConfigSource("doors_open"),
-                local_protection_id="unstored:entity_id",
-                disable_clear_notification_id="unstored:entity_id",
+                integration_info="unstored:integration_info",
                 priorities=("doors_open",),
             ),
             "stored_data": {
@@ -208,8 +207,7 @@ RESTORE_STATE_SCENARIOS = (
                     LEDConfig(80, effect=Effect.SOLID, duration=4, brightness=50.0),
                 ),
                 led_config_source=LEDConfigSource("doors_open"),
-                local_protection_id="unstored:entity_id",
-                disable_clear_notification_id="unstored:entity_id",
+                integration_info="unstored:integration_info",
                 priorities=("doors_open",),
             ),
             "stored_data": {
@@ -244,8 +242,7 @@ RESTORE_STATE_SCENARIOS = (
                 led_config_source=LEDConfigSource(
                     "lampie.override", LEDConfigSourceType.OVERRIDE
                 ),
-                local_protection_id="unstored:entity_id",
-                disable_clear_notification_id="unstored:entity_id",
+                integration_info="unstored:integration_info",
                 priorities=("doors_open",),
             ),
             "stored_data": {
@@ -278,6 +275,7 @@ RESTORE_STATE_SCENARIOS = (
             "switch_info": LampieSwitchInfo(
                 led_config=(),
                 led_config_source=LEDConfigSource(None),
+                integration_info="unstored:integration_info",
                 priorities=("doors_open",),
             ),
             "stored_data": {},
@@ -313,8 +311,7 @@ RESTORE_STATE_SCENARIOS = (
                     "switch_info": LampieSwitchInfo(
                         led_config=(LEDConfig(Color.BLUE, effect=Effect.SOLID),),
                         led_config_source=LEDConfigSource("doors_open"),
-                        local_protection_id="unstored:entity_id",
-                        disable_clear_notification_id="unstored:entity_id",
+                        integration_info="unstored:integration_info",
                         priorities=("doors_open",),
                     ),
                     "stored_data": {

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -35,7 +35,7 @@ def test_has_services(
     assert hass.services.has_service(DOMAIN, SERVICE_NAME_OVERRIDE)
 
 
-@pytest.mark.usefixtures("init_integration")
+@pytest.mark.usefixtures("switch", "init_integration")
 @pytest.mark.parametrize(
     "attrs",
     [


### PR DESCRIPTION
Supercedes #2 

* Rebased against `main`
* Modify how the params were being sent to Z2M, as the ZHA version wants `led_` prefixed on each key but Z2M just wants the key ([Inovelli docs](https://help.inovelli.com/en/articles/11357013-blue-series-led-notifications-with-mqtt-publish-zigbee2mqtt)). This matches how `LEDConfig` was already written
* Z2M does not accept integers for the effects so we need to send the effect string instead

- [x] Ensure the list of entities is properly filtering to just Inovelli switches in the config entry.
- [x] Verify that updating for a solid notification works.
- [x] Verify that updating for single LEDs works.
- [x] Ensure that double press on the config button ends up dismissing the notification (that the event handler is working properly).

Tested against z2m [v2.12.1](https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/releases/tag/v2.12.1-1)